### PR TITLE
Add release automation + tighten enforce-main-source against forks

### DIFF
--- a/.github/workflows/enforce-main-source.yml
+++ b/.github/workflows/enforce-main-source.yml
@@ -15,10 +15,18 @@ jobs:
   check-source-branch:
     runs-on: ubuntu-latest
     steps:
-      - name: Verify source is staging
+      - name: Verify source is staging from this repo
         run: |
+          # Reject fork PRs. Forks can only PR through staging in their own
+          # fork, and that source repo isn't this one — block them. Combined
+          # with the repo's collaborator list controlling who can push to
+          # this repo's staging, this gates main to repo-write-access only.
+          if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+            echo "::error::PRs to main must originate from a branch in this repo, not a fork. Source repo: ${{ github.event.pull_request.head.repo.full_name }}"
+            exit 1
+          fi
           if [ "${{ github.head_ref }}" != "staging" ]; then
             echo "::error::PRs to main must come from the 'staging' branch only. Got: '${{ github.head_ref }}'"
             exit 1
           fi
-          echo "PR source is 'staging' — OK"
+          echo "PR source is 'staging' from this repo — OK"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: Create release on tag push
+
+# Monorepo release automation. When a prefixed version tag
+# (<ModId>-vX.Y.Z) is pushed, create a corresponding GitHub Release.
+# Version 0.x.x tags are pre-releases; 1.x.x+ are full releases.
+# Releases are NOT marked --latest because "latest" doesn't make sense
+# across multiple mods in one repo (each mod has its own version cycle).
+# Release notes auto-generated from commit history since the previous tag.
+
+on:
+  push:
+    tags:
+      - '*-v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine release type
+        id: type
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          # Tag shape: <ModId>-v<X.Y.Z>. Extract the version after the LAST '-v'.
+          VERSION="${TAG##*-v}"
+          MAJOR="${VERSION%%.*}"
+          if [ "$MAJOR" = "0" ]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+            echo "Tag $TAG is 0.x.x — marking as pre-release"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+            echo "Tag $TAG is $MAJOR.x.x — marking as full release"
+          fi
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          if [ "${{ steps.type.outputs.prerelease }}" = "true" ]; then
+            gh release create "$TAG" --generate-notes --prerelease --title "$TAG" --latest=false
+          else
+            gh release create "$TAG" --generate-notes --title "$TAG" --latest=false
+          fi


### PR DESCRIPTION
Two related infra additions for the staging→main flow:

1. **`release.yml`** — when a `<ModId>-vX.Y.Z` tag is pushed, automatically create a GitHub Release with auto-generated notes. Version 0.x.x tags are pre-releases; 1.x.x+ are full releases. Releases are NOT marked `--latest` because "latest" doesn't make sense across multiple mods in a monorepo.

2. **`enforce-main-source.yml` tightening** — also rejects PRs from forks. Combined with the collaborator list, restricts main merges to repo-write-access only.

## Test plan
- [x] Release workflow file is valid YAML
- [x] enforce-main-source.yml syntax check
- [ ] Workflow runs on this PR (will become visible on PR creation)
- [ ] Status check `check-source-branch` passes (PR source IS staging in this repo)