### PR TITLE
Convert relative README links to absolute GitHub URLs for MW-safety

### DIFF
--- a/mods/CatAutoFeed/README.md
+++ b/mods/CatAutoFeed/README.md
@@ -55,11 +55,11 @@ Built for the Road to Vostok modding ecosystem. In-game configuration via the [M
 
 - **"Cat bowl"** by Justyna.sliwinska — [source](https://skfb.ly/otWXJ) — licensed under [CC BY 4.0](http://creativecommons.org/licenses/by/4.0/).
 
-See [NOTICES.txt](NOTICES.txt) for the verbatim attributions.
+See [NOTICES.txt](https://github.com/dwoodruff83/RoadToVostokMods/blob/main/mods/CatAutoFeed/NOTICES.txt) for the verbatim attributions.
 
 ## License
 
-[MIT](LICENSE) (mod code only — third-party 3D models retain their own CC BY 4.0 license; see NOTICES.txt).
+[MIT](https://github.com/dwoodruff83/RoadToVostokMods/blob/main/mods/CatAutoFeed/LICENSE) (mod code only — third-party 3D models retain their own CC BY 4.0 license; see NOTICES.txt).
 
 ## Source & Issues
 

--- a/mods/PunisherGuarantee/README.md
+++ b/mods/PunisherGuarantee/README.md
@@ -30,7 +30,7 @@ The vanilla Punisher event is gated three ways: a 10% possibility roll, a day-5 
 | Enable Spawn Hotkey | On | Press the configured key to spawn a Punisher near you. |
 | Spawn Hotkey | F10 | Key to press for the on-demand spawn. |
 
-Plus the standard Logger category (level, file output, overlay output). See [the RTV Mod Logger reference](../RTVModLogger/LOGGER.md) for details.
+Plus the standard Logger category (level, file output, overlay output). See [the RTV Mod Logger reference](https://github.com/dwoodruff83/RoadToVostokMods/blob/main/mods/RTVModLogger/LOGGER.md) for details.
 
 ## Compatibility
 
@@ -44,7 +44,7 @@ Built for the Road to Vostok modding ecosystem. In-game configuration via the [M
 
 ## License
 
-[MIT](LICENSE)
+[MIT](https://github.com/dwoodruff83/RoadToVostokMods/blob/main/mods/PunisherGuarantee/LICENSE)
 
 ## Source & Issues
 

--- a/mods/RTVModLogger/README.md
+++ b/mods/RTVModLogger/README.md
@@ -24,7 +24,7 @@ A modder tool. Copy `Logger.gd` into your mod, edit three lines, autoload it —
 - **Six log calls** — `debug` (gray), `info` (white), `success` (green), `warn` (orange), `error` (red), and `notify(msg, color)` which always shows regardless of filters.
 - **Three output targets**, each toggleable in MCM — Console, File (`user://MCM/<mod_id>/<filename>.log`), and in-game overlay (via `Loader.Message`).
 - **MCM integration helper** — one call adds Level / File / Overlay controls to your mod's existing MCM page.
-- **Schema-preserving migration** pattern (see [LOGGER.md](LOGGER.md)) — adding new settings between mod versions doesn't lose user values.
+- **Schema-preserving migration** pattern (see [LOGGER.md](https://github.com/dwoodruff83/RoadToVostokMods/blob/main/mods/RTVModLogger/LOGGER.md)) — adding new settings between mod versions doesn't lose user values.
 - **Coexistence** — each mod that uses the library has its own identity, log file, and MCM page. They don't conflict.
 
 ## Configuration (MCM)
@@ -35,7 +35,7 @@ A modder tool. Copy `Logger.gd` into your mod, edit three lines, autoload it —
 | Test Hotkey | F12 | Press in-game to fire the configured test action. |
 | Test Action | Test All | What the hotkey fires: `Test All` runs every level + a notify in sequence; or pick one specific level. |
 
-Plus the standard Logger category (level, file output, overlay output). See [LOGGER.md](LOGGER.md) for details.
+Plus the standard Logger category (level, file output, overlay output). See [LOGGER.md](https://github.com/dwoodruff83/RoadToVostokMods/blob/main/mods/RTVModLogger/LOGGER.md) for details.
 
 ## For modders: using `Logger.gd` in your mod
 
@@ -66,7 +66,7 @@ Plus the standard Logger category (level, file output, overlay output). See [LOG
    _log.notify("Boss spawned!", Color.RED)
    ```
 
-Full reference (MCM integration pattern, schema migration, troubleshooting): [LOGGER.md](LOGGER.md).
+Full reference (MCM integration pattern, schema migration, troubleshooting): [LOGGER.md](https://github.com/dwoodruff83/RoadToVostokMods/blob/main/mods/RTVModLogger/LOGGER.md).
 
 ## Compatibility
 
@@ -79,7 +79,7 @@ Built for the Road to Vostok modding ecosystem. In-game configuration via the [M
 
 ## License
 
-[MIT](LICENSE) — embed `Logger.gd` freely, with or without attribution.
+[MIT](https://github.com/dwoodruff83/RoadToVostokMods/blob/main/mods/RTVModLogger/LICENSE) — embed `Logger.gd` freely, with or without attribution.
 
 ## Source & Issues
 

--- a/mods/RTVWallets/README.md
+++ b/mods/RTVWallets/README.md
@@ -31,7 +31,7 @@ Find a wallet on a bandit, keep your rubles in it, spend at traders. Die with it
 |---|---|---|
 | Stash Report Hotkey | F9 | Press in-game to log every wallet you're carrying with its balance. Useful for a quick "what's my total cash" answer when split across tiers. |
 
-Plus the standard Logger category (level, file output, overlay output). See [the RTV Mod Logger reference](../RTVModLogger/LOGGER.md) for details.
+Plus the standard Logger category (level, file output, overlay output). See [the RTV Mod Logger reference](https://github.com/dwoodruff83/RoadToVostokMods/blob/main/mods/RTVModLogger/LOGGER.md) for details.
 
 ## Compatibility
 
@@ -51,11 +51,11 @@ Built for the Road to Vostok modding ecosystem. In-game configuration via the [M
 - **"Case with money | Low poly"** by tasha.kosaykina — [source](https://skfb.ly/6SJ7u) — [CC BY 4.0](http://creativecommons.org/licenses/by/4.0/).
 - **"Euro Banknote Stack Tied With Rubber"** by Dakta.Grower.Nzl — [source](https://skfb.ly/pCpXp) — [CC BY 4.0](http://creativecommons.org/licenses/by/4.0/).
 
-See [NOTICES.txt](NOTICES.txt) for the verbatim attributions.
+See [NOTICES.txt](https://github.com/dwoodruff83/RoadToVostokMods/blob/main/mods/RTVWallets/NOTICES.txt) for the verbatim attributions.
 
 ## License
 
-[MIT](LICENSE) (mod code only — third-party 3D models retain their own CC BY 4.0 license; see NOTICES.txt).
+[MIT](https://github.com/dwoodruff83/RoadToVostokMods/blob/main/mods/RTVWallets/LICENSE) (mod code only — third-party 3D models retain their own CC BY 4.0 license; see NOTICES.txt).
 
 ## Source & Issues
 


### PR DESCRIPTION
Pasting READMEs into ModWorkshop descriptions left relative links broken (MW renders standalone). Updated all four published-mod READMEs to use full GitHub URLs.