### PR TITLE
Add issue templates + chooser config for workspace repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,119 @@
+name: Bug report
+description: Something in one of the mods doesn't work the way it should
+title: "[Bug] "
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file this. The fields below ask for the
+        info needed to diagnose mod issues — mod version, game version, mod
+        loader version, and what other mods are installed are usually the
+        difference between "fixed in 5 minutes" and "spent a week trying to
+        reproduce."
+
+        Before filing, please check the mod's ModWorkshop comments (links in
+        the issue chooser) to see if anyone else hit the same thing.
+
+  - type: dropdown
+    id: mod
+    attributes:
+      label: Which mod?
+      description: Pick the affected mod. If the issue is in the workspace tooling (build scripts, scaffold, sync_logger, etc.), pick "Workspace tooling".
+      options:
+        - Cat Auto Feed
+        - RTV Mod Logger
+        - RTV Wallets
+        - Punisher Guarantee
+        - Workspace tooling
+        - Multiple / unsure
+    validations:
+      required: true
+
+  - type: input
+    id: mod_version
+    attributes:
+      label: Mod version
+      description: Found in the mod's ModWorkshop page or in the .vmz's mod.txt.
+      placeholder: e.g. 1.1.1
+    validations:
+      required: true
+
+  - type: input
+    id: game_version
+    attributes:
+      label: Game version
+      description: Shown in Road to Vostok's main menu, or via Steam library.
+      placeholder: e.g. 0.1.1.3
+    validations:
+      required: true
+
+  - type: input
+    id: loader_version
+    attributes:
+      label: Metro Mod Loader version
+      description: Shown in the launcher's Mods tab or in the loader's About panel.
+      placeholder: e.g. 3.1.1
+    validations:
+      required: true
+
+  - type: textarea
+    id: other_mods
+    attributes:
+      label: Other installed mods
+      description: List any other RTV mods you have enabled. Most "broken" reports turn out to be conflicts. Even if you think they're unrelated, list them.
+      placeholder: |
+        Wallet & Cash 2.9.1
+        Immortal Cat 1.0.3
+        ...
+    validations:
+      required: false
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: What did you do, in order, that triggered the issue?
+      placeholder: |
+        1. Loaded my Cabin save
+        2. Placed a Cat Food Bowl with 5 servings
+        3. Walked to Area 03
+        4. Waited 10 minutes
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs and screenshots
+      description: |
+        If the affected mod uses RTV Mod Logger (CatAutoFeed, RTVWallets do), the log file lives at
+        `%APPDATA%\Road to Vostok\MCM\<ModId>\<mod_id>.log`. Attach or paste relevant lines.
+
+        Screenshots help a lot for UI / loot / item-state issues — drag images directly into this field.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Confirmations
+      options:
+        - label: I searched existing issues and the mod's ModWorkshop comments
+          required: true
+        - label: I'm running the latest published version of the affected mod
+          required: false

--- a/.github/ISSUE_TEMPLATE/compatibility_report.yml
+++ b/.github/ISSUE_TEMPLATE/compatibility_report.yml
@@ -1,0 +1,90 @@
+name: Compatibility report
+description: Conflict between one of these mods and another mod
+title: "[Compat] "
+labels: [compatibility]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template when one of the mods in this repo conflicts with
+        another mod (anywhere — ModWorkshop, GitHub, or shared in Discord).
+        These reports are useful even when the fix isn't on our side, because
+        they help future users find a known-good config.
+
+  - type: dropdown
+    id: our_mod
+    attributes:
+      label: Mod from this repo
+      options:
+        - Cat Auto Feed
+        - RTV Mod Logger
+        - RTV Wallets
+        - Punisher Guarantee
+    validations:
+      required: true
+
+  - type: input
+    id: their_mod
+    attributes:
+      label: Conflicting mod (name + link)
+      description: Include a ModWorkshop or GitHub URL if you have one.
+      placeholder: e.g. Wallet & Cash by domfrags — https://modworkshop.net/mod/55951
+    validations:
+      required: true
+
+  - type: input
+    id: their_mod_version
+    attributes:
+      label: Conflicting mod version
+      placeholder: e.g. 2.9.1
+    validations:
+      required: false
+
+  - type: dropdown
+    id: conflict_type
+    attributes:
+      label: Conflict type
+      description: Pick the closest description. If multiple apply, pick the most severe.
+      options:
+        - Game crashes on launch
+        - Game crashes during play
+        - Items / scenes don't appear
+        - Double-feed / double-fire (mod runs twice)
+        - Save corruption
+        - UI / overlay broken
+        - Mods load but one silently does nothing
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What goes wrong
+      description: Describe the symptom. If the game crashes, paste the relevant lines from `%APPDATA%\Road to Vostok\modloader_conflicts.txt` or the Godot console output if you have it.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to make the conflict appear.
+    validations:
+      required: false
+
+  - type: textarea
+    id: workaround
+    attributes:
+      label: Workaround (if any)
+      description: e.g. "Disable mod B before loading", "Set load order so X is higher priority", etc.
+    validations:
+      required: false
+
+  - type: input
+    id: loader_version
+    attributes:
+      label: Metro Mod Loader version
+      placeholder: e.g. 3.1.1
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,15 @@
+blank_issues_enabled: false
+
+contact_links:
+  - name: Cat Auto Feed on ModWorkshop
+    url: https://modworkshop.net/mod/56407
+    about: Comments and ratings for the released mod live on its workshop page.
+  - name: RTV Mod Logger on ModWorkshop
+    url: https://modworkshop.net/mod/56406
+    about: Comments and ratings for the released mod live on its workshop page.
+  - name: RTV Wallets on ModWorkshop
+    url: https://modworkshop.net/mod/56408
+    about: Comments and ratings for the released mod live on its workshop page.
+  - name: Road to Vostok Discord
+    url: https://discord.com/invite/roadtovostok
+    about: General modding chat, troubleshooting help, mod-author conversations.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,61 @@
+name: Feature request
+description: Suggest a new feature, MCM toggle, or behavior change
+title: "[Feature] "
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea. Lead with the *problem* — what's frustrating about
+        playing with the current behavior? Concrete use cases get prioritized
+        over abstract "would be nice if" wishlists.
+
+  - type: dropdown
+    id: mod
+    attributes:
+      label: Which mod?
+      options:
+        - Cat Auto Feed
+        - RTV Mod Logger
+        - RTV Wallets
+        - Punisher Guarantee
+        - Workspace tooling
+        - New mod idea
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / use case
+      description: What player situation is this trying to address? Describe the pain point first.
+      placeholder: |
+        I run a long shelter expedition setup where I leave the cat for 3-4 in-game days.
+        The bowl runs dry after about 2 days, and even with shelter fallback enabled the
+        cat warns repeatedly because raw food in the cabinet ran out.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: What would the mod do differently?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds you tried, or other shapes the feature could take.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Confirmations
+      options:
+        - label: I searched existing issues for similar requests
+          required: true


### PR DESCRIPTION
Three structured forms (bug, feature, compatibility) plus a chooser config that disables blank issues and surfaces ModWorkshop pages + Discord. Tuned for the RTV monorepo's diagnostic needs (mod version, game version, loader version, other installed mods).