### PR TITLE
README: add Mod Releases table; drop GitHub repo-wide Latest flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # Road to Vostok Modding
 
+## Mod Releases
+
+This monorepo houses multiple mods, each with its own independent version. GitHub's "Latest" release flag is repo-singular — only one release can hold it at a time — so promoting any single mod to "Latest" implicitly demotes every other mod's most recent release. We leave the flag unset across the board and use this table instead. For the full release history (including pre-releases and retired mods), see [the Releases page](https://github.com/dwoodruff83/RoadToVostokMods/releases).
+
+| Mod | Version | Release tag | ModWorkshop |
+|-----|---------|-------------|-------------|
+| **Cat Auto Feed** | `1.1.2` | [CatAutoFeed-v1.1.2](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/CatAutoFeed-v1.1.2) | [56407](https://modworkshop.net/mod/56407) |
+| **RTV Mod Logger** | `1.0.1` | [RTVModLogger-v1.0.1](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/RTVModLogger-v1.0.1) | [56406](https://modworkshop.net/mod/56406) |
+| **RTV Wallets** | `1.0.1` | [RTVWallets-v1.0.1](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/RTVWallets-v1.0.1) | [56408](https://modworkshop.net/mod/56408) |
+| **Punisher Guarantee** | `0.1.0` | [PunisherGuarantee-v0.1.0](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/PunisherGuarantee-v0.1.0) | — (not yet published) |
+
 ## Game Info
 
 | Property | Value |


### PR DESCRIPTION
## Summary

Monorepo housekeeping for GitHub Releases.

GitHub's "Latest" release flag is repo-singular — only one release can hold it at a time. In a monorepo with multiple independently-versioned mods, promoting any single release to Latest implicitly demotes every other mod's most recent release. (Concretely: shipping CatAutoFeed-v1.1.2 displaced RTVWallets-v1.0.1 from Latest, even though RTVWallets-v1.0.1 is still the latest release of RTVWallets.)

- Add a "Mod Releases" table near the top of [README.md](README.md), listing each active mod's current version, release-tag link, and ModWorkshop page link.
- Already done out-of-band via `gh release edit CatAutoFeed-v1.1.2 --latest=false`: no release in this repo currently holds the Latest flag, by design. Future releases should also be created with `--latest=false`.
- Convention recorded in agent project memory so future sessions follow it without re-litigating.

## Test plan

- [x] Table renders correctly with all four active mods (CatAutoFeed, RTVModLogger, RTVWallets, PunisherGuarantee)
- [x] All release-tag links and ModWorkshop links resolve
- [x] CatAutoFeed-v1.1.2 currently holds no Latest flag
- [ ] After merge: pull main locally and force-sync staging back to it (already cleared the way for that)

🤖 Generated with [Claude Code](https://claude.com/claude-code)