### PR TITLE
Extend mw_stats.py with reply fetching + JSON comment archive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,10 @@ tools/DepotDownloader/
 # --- Steam-fetched / decompile scratch (regenerated each backfill) ---
 tools/_versions/
 
-# --- ModWorkshop stats history (operational data; regenerable from API) ---
+# --- ModWorkshop stats history + comment archive (operational data; regenerable from API) ---
 tools/mw_stats.csv
 tools/mw_stats_state.json
+tools/mw_comments_archive.json
 
 # --- Mod-impact diff reports (contain decompiled source diffs — keep local only) ---
 diff_reports/*

--- a/mods/RTVModLogger/CHANGELOG.md
+++ b/mods/RTVModLogger/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to the RTV Mod Logger are documented here. Dates are
 YYYY-MM-DD.
 
+## 1.0.1 — 2026-04-26
+
+Re-upload to register the ModWorkshop mod id (`modworkshop=56406` in
+`[updates]`). No functional changes from 1.0.0.
+
 ## 1.0.0 — 2026-04-25
 
 First public release. API is stable; embed `Logger.gd` freely.

--- a/mods/RTVWallets/CHANGELOG.md
+++ b/mods/RTVWallets/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to the RTV Wallets mod are documented here. Dates are
 YYYY-MM-DD.
 
+## 1.0.1 — 2026-04-26
+
+Re-upload to register the ModWorkshop mod id (`modworkshop=56408` in
+`[updates]`). No functional changes from 1.0.0.
+
 ## 1.0.0 — 2026-04-26
 
 First public release. Trader integration polished, MCM trimmed to settings

--- a/tools/mw_stats.py
+++ b/tools/mw_stats.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
-"""ModWorkshop stats snapshot + history logger.
+"""ModWorkshop stats snapshot + history logger + comment archive.
 
 Prints a current-stats table for monitored mods, computes deltas vs the
 previous CSV row (so you can see what's grown since last check), and
-appends a fresh timestamped row per mod to a CSV history. Also detects
-new comments since last run and shows them inline.
+appends a fresh timestamped row per mod to a CSV history. Also fetches
+comments + their replies, prints new ones, and persists the full
+comment-thread state to a JSON archive file you can mine later for a
+mod-issue knowledge base.
 
 Configuration
 -------------
@@ -15,9 +17,10 @@ Configuration
 
 Usage
 -----
-    python tools/mw_stats.py            # snapshot + delta + CSV append
-    python tools/mw_stats.py --no-csv   # snapshot + delta, no CSV write
-    python tools/mw_stats.py --comments # also show ALL comments, not just new
+    python tools/mw_stats.py             # snapshot + delta + CSV append + archive
+    python tools/mw_stats.py --no-csv    # skip CSV write
+    python tools/mw_stats.py --no-archive # skip JSON archive write
+    python tools/mw_stats.py --comments  # also show ALL comments, not just new
 """
 
 from __future__ import annotations
@@ -40,6 +43,7 @@ WORKSPACE_ROOT = Path(__file__).resolve().parent.parent
 MODS_DIR = WORKSPACE_ROOT / "mods"
 DEFAULT_CSV_PATH = WORKSPACE_ROOT / "tools" / "mw_stats.csv"
 DEFAULT_STATE_PATH = WORKSPACE_ROOT / "tools" / "mw_stats_state.json"
+DEFAULT_ARCHIVE_PATH = WORKSPACE_ROOT / "tools" / "mw_comments_archive.json"
 
 # Mods NOT in this workspace's mods/ folder but worth monitoring.
 # Format: list of (mod_id, display_name) tuples.
@@ -66,6 +70,15 @@ def fetch_mod(mod_id: int) -> dict:
 
 def fetch_comments(mod_id: int) -> dict:
     return fetch_json(f"{API_BASE}/mods/{mod_id}/comments")
+
+
+def fetch_replies(comment_id: int) -> list[dict]:
+    """Fetch replies for one top-level comment. Returns [] on any error."""
+    try:
+        resp = fetch_json(f"{API_BASE}/comments/{comment_id}/replies")
+    except (urllib.error.URLError, urllib.error.HTTPError, json.JSONDecodeError):
+        return []
+    return resp.get("data", []) or []
 
 
 # ---------- mod discovery ----------
@@ -139,6 +152,90 @@ def load_previous_snapshot(path: Path) -> dict[int, dict]:
     return rows_by_id
 
 
+# ---------- comment archive (the future-knowledge-base seed) ----------
+#
+# Shape of archive JSON:
+#   {
+#     "<mod_id>": {
+#       "mod_name": "...",
+#       "comments": {
+#         "<comment_id>": {
+#           "id": int, "user_name", "user_id", "content", "created_at",
+#           "updated_at", "first_seen_at", "last_seen_at",
+#           "replies": [ {id, user_name, user_id, content, created_at, updated_at}, ... ]
+#         },
+#         ...
+#       }
+#     },
+#     ...
+#   }
+#
+# Append-only by id: existing entries are *updated* with the latest fetched
+# state (so edits get reflected), but never deleted. first_seen_at records
+# when WE first saw it; last_seen_at records the most recent capture.
+
+
+def load_archive(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (ValueError, json.JSONDecodeError):
+        return {}
+
+
+def save_archive(path: Path, archive: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(archive, indent=2, sort_keys=True, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+
+def _user_fields(c: dict) -> tuple[str, int | None]:
+    user = c.get("user") or {}
+    return (user.get("name", "?"), user.get("id"))
+
+
+def update_archive(
+    archive: dict, mod_id: int, mod_name: str, comments: list[dict], timestamp: str
+) -> int:
+    """Merge fresh comment data into the archive. Returns count of NEW comments."""
+    mod_key = str(mod_id)
+    if mod_key not in archive:
+        archive[mod_key] = {"mod_name": mod_name, "comments": {}}
+    archive[mod_key]["mod_name"] = mod_name  # always refresh
+    bucket = archive[mod_key]["comments"]
+    new_count = 0
+    for c in comments:
+        cid = str(c.get("id"))
+        if cid not in bucket:
+            new_count += 1
+            bucket[cid] = {"first_seen_at": timestamp}
+        entry = bucket[cid]
+        user_name, user_id = _user_fields(c)
+        entry["id"] = int(c.get("id"))
+        entry["user_name"] = user_name
+        entry["user_id"] = user_id
+        entry["content"] = c.get("content", "")
+        entry["created_at"] = c.get("created_at")
+        entry["updated_at"] = c.get("updated_at")
+        entry["last_seen_at"] = timestamp
+        replies_out: list[dict] = []
+        for r in c.get("_replies", []) or []:
+            r_user_name, r_user_id = _user_fields(r)
+            replies_out.append({
+                "id": int(r.get("id")),
+                "user_name": r_user_name,
+                "user_id": r_user_id,
+                "content": r.get("content", ""),
+                "created_at": r.get("created_at"),
+                "updated_at": r.get("updated_at"),
+            })
+        entry["replies"] = replies_out
+    return new_count
+
+
 # ---------- rendering ----------
 
 
@@ -176,6 +273,27 @@ def render_table(snapshots: list[dict], previous: dict[int, dict]) -> str:
     return "\n".join(out)
 
 
+def render_comment_block(mod_name: str, mod_id: int, comments: list[dict]) -> list[str]:
+    """Render a list of (top-level comment + nested replies) as printable lines."""
+    out: list[str] = []
+    for c in comments:
+        user_name, _ = _user_fields(c)
+        created = c.get("created_at", "?")
+        content = (c.get("content") or "").strip()
+        out.append("")
+        out.append(f"  [{mod_name} ({mod_id})] {user_name} @ {created}")
+        for line in (content.splitlines() or [""]):
+            out.append(f"    {line}")
+        for r in c.get("_replies", []) or []:
+            r_user, _ = _user_fields(r)
+            r_created = r.get("created_at", "?")
+            r_content = (r.get("content") or "").strip()
+            out.append(f"    +-- reply by {r_user} @ {r_created}")
+            for line in (r_content.splitlines() or [""]):
+                out.append(f"        {line}")
+    return out
+
+
 # ---------- main ----------
 
 
@@ -184,10 +302,14 @@ def parse_args() -> argparse.Namespace:
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
     p.add_argument("--no-csv", action="store_true", help="Don't append a row to the CSV history")
+    p.add_argument("--no-archive", action="store_true",
+                   help="Don't update the JSON comment archive")
     p.add_argument("--csv-path", type=Path, default=DEFAULT_CSV_PATH,
                    help=f"CSV history path (default: {DEFAULT_CSV_PATH})")
     p.add_argument("--state-path", type=Path, default=DEFAULT_STATE_PATH,
                    help=f"State file for comment-id tracking (default: {DEFAULT_STATE_PATH})")
+    p.add_argument("--archive-path", type=Path, default=DEFAULT_ARCHIVE_PATH,
+                   help=f"JSON comment archive path (default: {DEFAULT_ARCHIVE_PATH})")
     p.add_argument("--comments", action="store_true",
                    help="Show all comments, not just new ones since last run")
     return p.parse_args()
@@ -197,11 +319,12 @@ def main() -> int:
     args = parse_args()
     mods = discover_workspace_mods() + EXTERNAL_MODS
     if not mods:
-        print("(no mods to monitor — add .publish files to mods/<X>/ or edit EXTERNAL_MODS)")
+        print("(no mods to monitor -- add .publish files to mods/<X>/ or edit EXTERNAL_MODS)")
         return 1
 
     state = load_state(args.state_path)
     previous = load_previous_snapshot(args.csv_path)
+    archive = load_archive(args.archive_path)
     timestamp = datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
 
     snapshots: list[dict] = []
@@ -227,6 +350,15 @@ def main() -> int:
         comment_total = comments_resp.get("meta", {}).get("total", 0)
         comments = comments_resp.get("data", []) or []
 
+        # Attach replies in-place. Most comments have replies_count=0 so this
+        # adds zero HTTP calls in the common case.
+        for c in comments:
+            try:
+                rcount = int(c.get("replies_count") or 0)
+            except (TypeError, ValueError):
+                rcount = 0
+            c["_replies"] = fetch_replies(int(c["id"])) if rcount > 0 else []
+
         snapshots.append({
             "timestamp": timestamp,
             "mod_id": info.get("id", mod_id),
@@ -237,6 +369,17 @@ def main() -> int:
             "likes": info.get("likes", 0),
             "comments": comment_total,
         })
+
+        # Merge into long-term archive (idempotent: existing entries get updated,
+        # new ones appended).
+        if not args.no_archive:
+            update_archive(
+                archive,
+                int(info.get("id", mod_id)),
+                info.get("name", fallback_name),
+                comments,
+                timestamp,
+            )
 
         # Comment ids are integers; track the max we've seen to detect new ones next run.
         last_seen_id = state.get(str(mod_id), 0)
@@ -259,24 +402,23 @@ def main() -> int:
 
     if new_comments_by_mod:
         print()
-        header = "All comments:" if args.comments else "New comments since last run:"
+        header = "All comments (and replies):" if args.comments else "New comments since last run:"
         print(header)
         for mod_id, comments in new_comments_by_mod.items():
             mod_name = next((s["name"] for s in snapshots if s["mod_id"] == mod_id), str(mod_id))
-            for c in comments:
-                user_field = c.get("user")
-                user = user_field.get("name", "?") if isinstance(user_field, dict) else "?"
-                created = c.get("created_at", "?")
-                body = (c.get("body") or "").strip()
-                print()
-                print(f"  [{mod_name} ({mod_id})] {user} @ {created}")
-                for line in body.splitlines() or [""]:
-                    print(f"    {line}")
+            for line in render_comment_block(mod_name, mod_id, comments):
+                print(line)
 
     if not args.no_csv:
         append_csv(args.csv_path, snapshots)
         print()
         print(f"[csv] appended {len(snapshots)} rows to {args.csv_path}")
+
+    if not args.no_archive:
+        save_archive(args.archive_path, archive)
+        total_threads = sum(len(m.get("comments", {})) for m in archive.values())
+        print(f"[archive] {total_threads} comment threads in {args.archive_path}")
+
     save_state(args.state_path, state)
     return 0
 


### PR DESCRIPTION
Fixes the body→content field-name bug (caught when first real comment came through with empty body), adds reply-thread fetching per top-level comment, and persists full thread state to a gitignored JSON archive that can later seed a mod-issue knowledge base.