### PR TITLE
Fix CatAutoFeed bowl-storage sharing across instances (#18)

### DIFF
--- a/mods/CatAutoFeed/BowlPickup.gd
+++ b/mods/CatAutoFeed/BowlPickup.gd
@@ -15,6 +15,16 @@ const FOOD_NAMES := ["Cat_Food", "Canned_Meat", "Canned_Tuna", "Perch"]
 const MAX_SERVINGS := 10
 
 func _ready() -> void:
+    # Heal save-data bowls written before the local_to_scene fix landed:
+    # those bowls' SlotData was serialized while shared, so multiple bowls in
+    # the same save can still point to the same SlotData object on load even
+    # with the .tscn-side fix in place. Duplicate it here so each bowl ends
+    # up with its own storage going forward. One-shot per bowl per save —
+    # subsequent loads see resource_local_to_scene = true and skip.
+    if slotData != null and not slotData.resource_local_to_scene:
+        slotData = slotData.duplicate(true)
+        slotData.resource_local_to_scene = true
+
     var mesh_inst: MeshInstance3D = null
     if mesh != null:
         mesh_inst = mesh

--- a/mods/CatAutoFeed/Cat_Bowl.tscn
+++ b/mods/CatAutoFeed/Cat_Bowl.tscn
@@ -7,6 +7,7 @@
 [ext_resource type="PhysicsMaterial" path="res://Items/Physics/Item_Physics.tres" id="5"]
 
 [sub_resource type="Resource" id="Resource_slot"]
+resource_local_to_scene = true
 script = ExtResource("4")
 itemData = ExtResource("3")
 


### PR DESCRIPTION
## Summary

Closes #18.

ModWorkshop bug report from Hun Alexander on mod 56407: placing a second Cat Food Bowl emptied the existing bowl's contents, and food added to one bowl appeared in every bowl simultaneously.

Root cause: `Cat_Bowl.tscn`'s inline `SlotData` sub-resource was missing `resource_local_to_scene = true`. Without that flag, every instance of `Cat_Bowl.tscn` shared the same `SlotData` object — and thus the same `storage` Array.

Two fixes:

- **`Cat_Bowl.tscn`**: set `resource_local_to_scene = true` on the embedded `SlotData`. Each new bowl spawn now gets its own independent SlotData.
- **`BowlPickup.gd._ready()`**: defensive heal that duplicates non-local-to-scene SlotData at load time. Auto-fixes existing-save bowls that were serialized while shared. Self-disables after one trigger per bowl per save.

No version bump or CHANGELOG entry in this PR by design — fix is locally verified, but we have additional work in flight (#19 in-shelter feature, #20 bowl-clipping fix) before the next publish. The version bump and consolidated changelog entry land in the publish PR once everything in this fix-cycle is queued up.

## Test plan

- [x] Place new bowl from inventory next to existing food-filled bowl — neither is emptied
- [x] Add food to one bowl — food stays in only that bowl, doesn't appear in siblings
- [x] Confirmed by user empirically (two independent bowls in shelter at the same time)
- [x] Heal is no-op for fresh installs (`.tscn` flag is set, `_ready()` check returns false)
- [ ] Acceptance criterion from #18: 20+ placements without storage corruption (informally satisfied during local play)

🤖 Generated with [Claude Code](https://claude.com/claude-code)