### PR TITLE
Fix CatAutoFeed bowl dark-line artifacts at distance (#22)

### DIFF
--- a/mods/CatAutoFeed/BowlPickup.gd
+++ b/mods/CatAutoFeed/BowlPickup.gd
@@ -44,6 +44,20 @@ func _ready() -> void:
         if base_mat is StandardMaterial3D:
             var tinted: StandardMaterial3D = base_mat.duplicate()
             tinted.albedo_color = tinted.albedo_color.darkened(0.45)
+            # Bypass mipmaps to suppress dark-seam artifacts that appear at
+            # distance. The artifacts come from S3TC compression blocks baked
+            # into the lower mip levels of the GLB's embedded texture — no
+            # texture-filter setting (anisotropic, etc.) can mask them
+            # because the dark pixels are in the mip data itself. Sampling
+            # the full-resolution texture at all distances avoids the
+            # compressed lower mips entirely. Trade-off: mild aliasing at
+            # the bowl rim when viewed from a few metres. Bowl is small in
+            # screen space at that range and the aliasing is barely visible.
+            #
+            # A cleaner future fix would be to re-import the GLB's embedded
+            # texture as lossless (no S3TC), which preserves working
+            # mipmaps. Tracked separately as a follow-up.
+            tinted.texture_filter = BaseMaterial3D.TEXTURE_FILTER_LINEAR
             mesh_inst.material_override = tinted
         mesh_inst.visibility_range_end = 0
         _smooth_mesh_normals(mesh_inst)


### PR DESCRIPTION
## Summary

Closes #22.

Faint dark lines appearing on the bowl interior at distance were caused by S3TC compression blocks baked into the lower mip levels of the GLB's embedded texture, which produce darker pixels at UV-island boundaries (the cat-face decal edge and the cylindrical-wrap seams). No texture-filter setting could mask them because the dark pixels are in the mipmap data itself, not in how it's sampled.

Fix: set the bowl's runtime material `texture_filter` to `TEXTURE_FILTER_LINEAR` (no mipmaps). Forces full-resolution texture sampling at all distances, sidestepping the compressed lower mips entirely.

## Trade-off

Mild rim aliasing visible at distance (because the GPU now has to sample full-res texture even when the bowl is small on screen). Confirmed acceptable during local testing — "doesn't look too bad, just a bit of aliasing by the rim/top". Cleaner future path: re-importing the GLB's embedded texture as lossless to restore working mipmaps without compression seams. Will file as a follow-up polish issue.

## Diagnostic narrative

Two false starts ruled out before landing on the fix:
- `mesh_lod_threshold = 0` (no effect — GLB import already has `generate_lods=false`)
- `TEXTURE_FILTER_LINEAR_WITH_MIPMAPS_ANISOTROPIC` (no effect even with 8x anisotropic enabled at the project level — confirmed the artifact is in the mip data, not the sampling pattern)
- `TEXTURE_FILTER_LINEAR` (no mipmaps) — lines gone, confirming mipmaps were the source

## Test plan

- [x] Walk away from a placed bowl to a few metres — no dark lines on bowl interior
- [x] Up close — bowl looks unchanged from before
- [x] Mild rim aliasing at distance is acceptable per user
- [ ] No version bump or CHANGELOG entry — bundled with #20 and any other polish in the next publish PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)