### PR TITLE
Skip CatAutoFeed clip-correction during placement (KINEMATIC freeze_mode)

### DIFF
--- a/mods/CatAutoFeed/BowlPickup.gd
+++ b/mods/CatAutoFeed/BowlPickup.gd
@@ -242,6 +242,17 @@ func _physics_process(delta: float) -> void:
     if _clip_check_timer > 0.0:
         return
     _clip_check_timer = CLIP_CHECK_INTERVAL
+    # Skip during placement and inventory-held states. Vanilla Pickup uses
+    # three states (see Pickup.gd):
+    #   - Freeze(): freeze=true, mode=STATIC — bowl is parked / pre-placement
+    #   - Kinematic(): freeze=false, mode=KINEMATIC — placement preview, the
+    #     player is positioning via aim/scroll/middle-click
+    #   - Unfreeze(): freeze=false, mode=STATIC — physics-active or settled
+    # We only want to clip-correct in the Unfreeze state. Running the raycast
+    # during placement would snap the bowl to whatever surface is beneath
+    # the current aim point, ignoring where the player intends to place it.
+    if freeze or freeze_mode == FREEZE_MODE_KINEMATIC:
+        return
     # Only correct while at rest — a bowl mid-flight is legitimately moving
     # through space and shouldn't be teleported.
     if linear_velocity.length_squared() > 0.0025:  # > 5cm/s


### PR DESCRIPTION
## Summary

The continuous clip-correction added in #27 was firing during placement preview, snapping the bowl to whatever surface the raycast happened to find beneath the current aim point. Symptom: aim at a lower shelf, bowl jumps onto the upper shelf above it before you can commit the placement.

Updates the gate in \`_physics_process\` to also skip when \`freeze_mode == FREEZE_MODE_KINEMATIC\` — the placement-preview state. Vanilla Pickup uses three states; the previous \`if freeze: return\` only caught one of them.

## State table (vanilla \`Pickup.gd\`)

| State | freeze | freeze_mode | Should clip-correct? |
|-------|--------|-------------|----------------------|
| \`Freeze()\` | true | STATIC | No (parked) |
| \`Kinematic()\` | false | **KINEMATIC** | **No** (placement preview) ← was firing here |
| \`Unfreeze()\` | false | STATIC | Yes (in flight / settled) |

## Test plan

- [x] Place a bowl on a lower shelf with another shelf above it — no snap to upper shelf during preview
- [x] Drop a bowl onto a flat surface — clip-correction still fires when the bowl settles
- [x] No regression to other recent fixes (#18, #19, #20, #22)

## Note about #28

This branch was originally cut for #28 (bowl falls through world, doesn't auto-recover). Investigation found that vanilla DOES have a recovery system (\`Killbox.gd\`) but it can't reach items that clip through one floor layer and land on intermediate geometry above the killbox volume — same vanilla physics limitation that loses normal items (Board Game, Gum, etc.) the same way. Out of scope to fix from the mod side without implementing a custom out-of-bounds watcher. Will follow up on #28 separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)