### PR TITLE
Publish CatAutoFeed 1.1.4: placement physics + rendering polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This monorepo houses multiple mods, each with its own independent version. GitHu
 
 | Mod | Version | Release tag | ModWorkshop |
 |-----|---------|-------------|-------------|
-| **Cat Auto Feed** | `1.1.3` | [CatAutoFeed-v1.1.3](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/CatAutoFeed-v1.1.3) | [56407](https://modworkshop.net/mod/56407) |
+| **Cat Auto Feed** | `1.1.4` | [CatAutoFeed-v1.1.4](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/CatAutoFeed-v1.1.4) | [56407](https://modworkshop.net/mod/56407) |
 | **RTV Mod Logger** | `1.0.1` | [RTVModLogger-v1.0.1](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/RTVModLogger-v1.0.1) | [56406](https://modworkshop.net/mod/56406) |
 | **RTV Wallets** | `1.0.1` | [RTVWallets-v1.0.1](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/RTVWallets-v1.0.1) | [56408](https://modworkshop.net/mod/56408) |
 | **Punisher Guarantee** | `0.1.0` | [PunisherGuarantee-v0.1.0](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/PunisherGuarantee-v0.1.0) | — (not yet published) |

--- a/mods/CatAutoFeed/BowlPickup.gd
+++ b/mods/CatAutoFeed/BowlPickup.gd
@@ -14,6 +14,16 @@ const PANEL_SCRIPT_PATH := "res://mods/CatAutoFeed/BowlContentsPanel.gd"
 const FOOD_NAMES := ["Cat_Food", "Canned_Meat", "Canned_Tuna", "Perch"]
 const MAX_SERVINGS := 10
 
+# Y of the bowl mesh's lowest point in RB-local space, captured during
+# collision setup. Used by the clip-correction code to compute where the
+# bowl's RB origin should sit so the visual bottom rests on the surface.
+var _bowl_bottom_offset_y: float = 0.0
+
+# Periodic clip check: every CLIP_CHECK_INTERVAL seconds, if the bowl is at
+# rest, raycast down to verify it's not slowly sinking into a surface.
+const CLIP_CHECK_INTERVAL := 0.5
+var _clip_check_timer := 0.0
+
 func _ready() -> void:
     # Heal save-data bowls written before the local_to_scene fix landed:
     # those bowls' SlotData was serialized while shared, so multiple bowls in
@@ -25,19 +35,33 @@ func _ready() -> void:
         slotData = slotData.duplicate(true)
         slotData.resource_local_to_scene = true
 
-    var mesh_inst: MeshInstance3D = null
-    if mesh != null:
-        mesh_inst = mesh
-    else:
-        var meshes := find_children("*", "MeshInstance3D", true, false)
-        if meshes.size() > 0:
-            mesh_inst = meshes[0]
-            mesh = mesh_inst
+    # Enable continuous collision detection so a fast-thrown bowl can't
+    # tunnel through the table between physics ticks. Discrete CD samples
+    # at fixed intervals and can miss overlaps when the bowl traverses
+    # more than its own thickness in one step (which happens easily with
+    # a player-tossed item).
+    continuous_cd = true
+
+    # Lock pitch/roll rotation. Works in tandem with the spawn-Y correction
+    # below: when a bowl spawns slightly clipped, physics needs to resolve
+    # the penetration. Without this lock, the solver applies both linear
+    # AND angular forces, and the bowl can tip-and-wedge itself further
+    # into the surface instead of climbing out. With rotation pinned to
+    # yaw-only, the only resolution path is upward translation, which is
+    # what we want. Mild loss of "throw it hard and watch it tumble"
+    # realism is acceptable for a placeable item.
+    axis_lock_angular_x = true
+    axis_lock_angular_z = true
+
+    var meshes := find_children("*", "MeshInstance3D", true, false)
+    var mesh_inst: MeshInstance3D = meshes[0] if meshes.size() > 0 else null
 
     if mesh_inst and collision and mesh_inst.mesh:
-        # Hand-tuned primitives beat auto-generated convex hulls for dropped
-        # items in RTV — vanilla uses simple BoxShape3D for every consumable.
-        _setup_box_collision_from_aabb(mesh_inst)
+        # Build a snug cylinder collision from the actual mesh AABB. The
+        # .tscn-defined placeholder shape is a stand-in for editor preview;
+        # the bowl's real shape is closer to a cylinder than a box, so a
+        # cylinder hugs it more tightly while still being a simple primitive.
+        _setup_cylinder_collision_from_aabb(mesh_inst)
 
     if mesh_inst:
         var base_mat := mesh_inst.get_active_material(0)
@@ -61,6 +85,28 @@ func _ready() -> void:
             mesh_inst.material_override = tinted
         mesh_inst.visibility_range_end = 0
         _smooth_mesh_normals(mesh_inst)
+
+    # Tiny invisible proxy MeshInstance3D for vanilla Placer's get_aabb()
+    # call — without it, Placer would see the GLB's raw Sketchfab mesh
+    # bounds (source units render as tens of metres in Godot), mis-position
+    # the bowl on placement, and the resulting offset between visual and
+    # collision causes the bowl to intermittently clip through surfaces.
+    # Same proxy trick used by the RTV Wallets mod.
+    var proxy := MeshInstance3D.new()
+    proxy.name = "MeshProxy"
+    var proxy_box := BoxMesh.new()
+    proxy_box.size = Vector3(0.16, 0.07, 0.16)
+    proxy.mesh = proxy_box
+    proxy.visible = false
+    add_child(proxy)
+    mesh = proxy
+
+    # After vanilla setup finishes, verify our spawn Y isn't below the
+    # surface beneath us — vanilla Placer occasionally mis-positions the
+    # bowl on fast upright placements, baking the bowl into the table.
+    # Deferred so the bowl is fully in the scene tree when the raycast runs.
+    call_deferred("_correct_spawn_position")
+
     super()
     _recompute_amount()
 
@@ -182,6 +228,55 @@ func _recompute_amount() -> void:
     if slotData != null:
         slotData.amount = total_servings()
 
+func _correct_spawn_position() -> void:
+    var lift := _compute_lift_to_clear_surface()
+    if lift > 0.0:
+        global_position.y += lift
+
+# Periodic clip correction. Same raycast as the spawn check, but runs while
+# the bowl is at rest — if vanilla physics has let the bowl drift slowly
+# into a surface (residual penetration that the solver can't fully resolve
+# tick-by-tick), lift it back out and zero linear velocity so it stays put.
+func _physics_process(delta: float) -> void:
+    _clip_check_timer -= delta
+    if _clip_check_timer > 0.0:
+        return
+    _clip_check_timer = CLIP_CHECK_INTERVAL
+    # Only correct while at rest — a bowl mid-flight is legitimately moving
+    # through space and shouldn't be teleported.
+    if linear_velocity.length_squared() > 0.0025:  # > 5cm/s
+        return
+    var lift := _compute_lift_to_clear_surface()
+    if lift > 0.0:
+        global_position.y += lift
+        linear_velocity = Vector3.ZERO
+
+# Cast a short vertical ray from just above the bowl down past where the
+# bowl is sitting; if we find a static surface, return the upward distance
+# the RB origin needs to move so the bowl's visual bottom is at-or-above
+# the surface (with a 2mm safety margin). Returns 0 if no correction needed.
+func _compute_lift_to_clear_surface() -> float:
+    if not is_inside_tree():
+        return 0.0
+    var space := get_world_3d().direct_space_state
+    if space == null:
+        return 0.0
+    var origin := global_position
+    var query := PhysicsRayQueryParameters3D.create(
+        origin + Vector3(0, 0.5, 0),
+        origin + Vector3(0, -0.5, 0)
+    )
+    query.exclude = [self.get_rid()]
+    var result := space.intersect_ray(query)
+    if result.is_empty():
+        return 0.0
+    var surface_y: float = result.position.y
+    # Bowl visual bottom in world space = rb_origin.y + _bowl_bottom_offset_y.
+    # For the bowl to rest on the surface, rb_origin.y should equal
+    # surface_y - _bowl_bottom_offset_y. Add 2mm so the bowl is just above.
+    var desired_y := surface_y - _bowl_bottom_offset_y + 0.002
+    return max(0.0, desired_y - origin.y)
+
 func _open_panel() -> void:
     var panel_script = load(PANEL_SCRIPT_PATH)
     if panel_script == null:
@@ -203,9 +298,9 @@ func _open_panel() -> void:
     canvas.add_child(panel)
     panel.open(self)
 
-# --- Mesh / collision setup (unchanged from previous revision) ---
+# --- Mesh / collision setup ---
 
-func _setup_box_collision_from_aabb(mi: MeshInstance3D) -> void:
+func _setup_cylinder_collision_from_aabb(mi: MeshInstance3D) -> void:
     if mi.mesh == null or collision == null:
         return
     # AABB is in mesh-local space; transform it into RigidBody-local space.
@@ -213,14 +308,20 @@ func _setup_box_collision_from_aabb(mi: MeshInstance3D) -> void:
     var mesh_to_rb: Transform3D = global_transform.affine_inverse() * mi.global_transform
     var rb_aabb: AABB = mesh_to_rb * local_aabb
 
-    var box := BoxShape3D.new()
-    # Clamp to a minimum size so any zero-thickness AABB axis doesn't produce
-    # a degenerate box.
-    box.size = Vector3(max(rb_aabb.size.x, 0.01), max(rb_aabb.size.y, 0.01), max(rb_aabb.size.z, 0.01))
-    collision.shape = box
+    var cylinder := CylinderShape3D.new()
+    # Radius wraps the larger of X/Z half-extents with a small margin so the
+    # cylinder slightly overhangs the bowl rim — gives physics resolution
+    # some breathing room without looking obviously oversized.
+    cylinder.radius = max(max(rb_aabb.size.x, rb_aabb.size.z) * 0.5 * 1.05, 0.01)
+    # Height matches full Y extent of the mesh, also with a touch of margin.
+    cylinder.height = max(rb_aabb.size.y * 1.05, 0.01)
+    collision.shape = cylinder
     collision.position = rb_aabb.get_center()
     collision.rotation = Vector3.ZERO
     collision.scale = Vector3.ONE
+    # Cache the AABB's lowest point so _correct_spawn_position() knows
+    # where the bowl's visual bottom sits relative to its RB origin.
+    _bowl_bottom_offset_y = rb_aabb.position.y
 
 # Sketchfab GLBs often ship with per-face (flat) normals, causing dark polygon
 # edges to show up as shading artifacts. Rebuild the surface with smooth

--- a/mods/CatAutoFeed/BowlPickup.gd
+++ b/mods/CatAutoFeed/BowlPickup.gd
@@ -44,6 +44,20 @@ func _ready() -> void:
         if base_mat is StandardMaterial3D:
             var tinted: StandardMaterial3D = base_mat.duplicate()
             tinted.albedo_color = tinted.albedo_color.darkened(0.45)
+            # Bypass mipmaps to suppress dark-seam artifacts that appear at
+            # distance. The artifacts come from S3TC compression blocks baked
+            # into the lower mip levels of the GLB's embedded texture — no
+            # texture-filter setting (anisotropic, etc.) can mask them
+            # because the dark pixels are in the mip data itself. Sampling
+            # the full-resolution texture at all distances avoids the
+            # compressed lower mips entirely. Trade-off: mild aliasing at
+            # the bowl rim when viewed from a few metres. Bowl is small in
+            # screen space at that range and the aliasing is barely visible.
+            #
+            # A cleaner future fix would be to re-import the GLB's embedded
+            # texture as lossless (no S3TC), which preserves working
+            # mipmaps. Tracked separately as a follow-up.
+            tinted.texture_filter = BaseMaterial3D.TEXTURE_FILTER_LINEAR
             mesh_inst.material_override = tinted
         mesh_inst.visibility_range_end = 0
         _smooth_mesh_normals(mesh_inst)

--- a/mods/CatAutoFeed/BowlPickup.gd
+++ b/mods/CatAutoFeed/BowlPickup.gd
@@ -242,6 +242,17 @@ func _physics_process(delta: float) -> void:
     if _clip_check_timer > 0.0:
         return
     _clip_check_timer = CLIP_CHECK_INTERVAL
+    # Skip during placement and inventory-held states. Vanilla Pickup uses
+    # three states (see Pickup.gd):
+    #   - Freeze(): freeze=true, mode=STATIC — bowl is parked / pre-placement
+    #   - Kinematic(): freeze=false, mode=KINEMATIC — placement preview, the
+    #     player is positioning via aim/scroll/middle-click
+    #   - Unfreeze(): freeze=false, mode=STATIC — physics-active or settled
+    # We only want to clip-correct in the Unfreeze state. Running the raycast
+    # during placement would snap the bowl to whatever surface is beneath
+    # the current aim point, ignoring where the player intends to place it.
+    if freeze or freeze_mode == FREEZE_MODE_KINEMATIC:
+        return
     # Only correct while at rest — a bowl mid-flight is legitimately moving
     # through space and shouldn't be teleported.
     if linear_velocity.length_squared() > 0.0025:  # > 5cm/s

--- a/mods/CatAutoFeed/CHANGELOG.md
+++ b/mods/CatAutoFeed/CHANGELOG.md
@@ -3,6 +3,56 @@
 All notable changes to the Cat Auto Feed mod are documented here. Dates are
 YYYY-MM-DD.
 
+## 1.1.4 — 2026-04-29
+
+Bowl placement physics polish and a fix for distance-view rendering
+artifacts. Three issues addressed (#20, #22, #29). No gameplay or save
+format changes — purely visual + physics quality of life.
+
+- **Fast upright placements no longer clip the bowl into the table.** The
+  Cat Food Bowl's hollow upward-facing shape exposed an edge case in
+  vanilla physics where fast placements could spawn the bowl partially
+  below a target surface, with the rigid-body solver unable to fully
+  resolve the penetration tick-by-tick (gravity wins the contest, the
+  bowl slowly sinks deeper). Fix is a layered defence:
+  - Cylinder collision sized from the actual mesh AABB at runtime, with a
+    5% margin so it slightly overhangs the bowl rim.
+  - Wallet-style invisible proxy `MeshInstance3D` so vanilla `Placer`'s
+    `get_aabb()` query sees clean bounds rather than the GLB's raw
+    Sketchfab units.
+  - Spawn-Y correction: at `_ready()`, raycast down to find the surface
+    beneath the bowl; lift the body if vanilla Placer mis-positioned us.
+  - Pitch/roll rotation lock so the solver can't apply torque that would
+    wedge a clipped bowl deeper instead of climbing it out.
+  - Continuous in-process clip-correction: same raycast as the spawn
+    check, gated to a 0.5-second timer and run only while the bowl is
+    at rest. If the spawn correction missed and the bowl is residual-
+    drifting into a surface, lift it back up and zero linear velocity
+    so it stays put.
+  - Continuous collision detection (`continuous_cd = true`) for fast-motion
+    tunneling defence.
+- **Faint dark lines on the bowl at distance are gone.** Cause was the
+  GLB's embedded texture being imported with default S3TC compression;
+  at lower mipmap levels, the 4×4 block compression produces darker
+  pixels at UV-island boundaries (the cat-face decal edge and the
+  cylindrical wrap seam), which appear as faint dark lines once the
+  bowl is small enough on screen for the GPU to sample those mip levels.
+  No texture-filter tweak (anisotropic, etc.) masks them because the
+  dark pixels are baked into the mip data itself. Fix: set the bowl's
+  runtime material `texture_filter` to `TEXTURE_FILTER_LINEAR` (no
+  mipmaps), forcing full-resolution sampling at all distances. Mild
+  rim aliasing at distance is the trade-off; barely visible because
+  the bowl is small in screen space at that range. A cleaner fix
+  (lossless texture re-import to keep working mipmaps) is tracked
+  separately as a future polish task.
+- **Placement preview no longer snaps the bowl to nearby shelves.** A
+  regression from the clip-correction work above: while the player was
+  positioning the bowl in placement preview, the same raycast was
+  detecting nearby surfaces and lifting the bowl onto them, even when
+  the player wasn't aiming there. Fix: gate the clip-correction on
+  `freeze_mode != FREEZE_MODE_KINEMATIC` so it only runs when the bowl
+  is in the post-drop physics-active state, not during placement preview.
+
 ## 1.1.3 — 2026-04-28
 
 Bowl-storage corruption fix and a user-requested in-shelter auto-feed

--- a/mods/CatAutoFeed/Cat_Bowl.tscn
+++ b/mods/CatAutoFeed/Cat_Bowl.tscn
@@ -11,9 +11,8 @@ resource_local_to_scene = true
 script = ExtResource("4")
 itemData = ExtResource("3")
 
-[sub_resource type="CylinderShape3D" id="CylinderShape3D_bowl"]
-radius = 0.08
-height = 0.06
+[sub_resource type="BoxShape3D" id="BoxShape3D_placeholder"]
+size = Vector3(0.20, 0.10, 0.20)
 
 [node name="Cat_Bowl" type="RigidBody3D" node_paths=PackedStringArray("collision") groups=["Item"]]
 collision_layer = 4
@@ -27,5 +26,5 @@ collision = NodePath("Collision")
 transform = Transform3D(0.075, 0, 0, 0, 0.075, 0, 0, 0, 0.075, 0, 0.04, 0)
 
 [node name="Collision" type="CollisionShape3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.03, 0)
-shape = SubResource("CylinderShape3D_bowl")
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.04, 0)
+shape = SubResource("BoxShape3D_placeholder")

--- a/mods/CatAutoFeed/mod.txt
+++ b/mods/CatAutoFeed/mod.txt
@@ -1,7 +1,7 @@
 [mod]
 name="Cat Auto Feed"
 id="CatAutoFeed"
-version="1.1.3"
+version="1.1.4"
 
 [autoload]
 CatAutoFeedLog="res://mods/CatAutoFeed/Logger.gd"


### PR DESCRIPTION
## Summary

Promotes four staging commits to main as the CatAutoFeed v1.1.4 publish bundle.

### What's in this release

**Closes #20 — Bowl no longer clips into surfaces on fast upright placements.**
Layered defence: AABB-derived cylinder collision + 5% margin, wallet-style invisible proxy mesh for Placer, spawn-Y raycast correction, pitch/roll rotation lock, continuous in-process clip-correction (0.5s timer, only while at rest), and CCD. Each addressed a different failure mode from the diagnostic narrative.

**Closes #22 — Faint dark lines at distance are gone.**
Root cause was S3TC compression at lower mipmap levels producing dark pixels at UV-island boundaries (cat-face decal edge, cylindrical wrap seam). Fixed by setting the runtime material's \`texture_filter\` to \`TEXTURE_FILTER_LINEAR\` (no mipmaps), bypassing the compressed lower mips entirely. Mild rim aliasing at distance as the trade-off.

**Closes #29 — Placement preview no longer snaps the bowl to nearby shelves.**
A regression from #20: the continuous clip-correction was firing during placement preview (vanilla \`Pickup.Kinematic\` state), grabbing whatever surface the raycast found beneath the current aim point. Gated on \`freeze_mode != FREEZE_MODE_KINEMATIC\` so it only runs in the post-drop physics-active state.

**Bookkeeping:**
- \`mod.txt\` 1.1.3 → 1.1.4
- CHANGELOG entry consolidating all three changes
- README "Mod Releases" table updated

### Deferred

- #26 Lossless texture re-import (cleaner #22 fix without rim aliasing) — future polish
- #28 Bowl no-recovery on fall-through — vanilla Attic geometry limitation, deferred per investigation findings

## Test plan

- [x] Slow placement (any orientation) — bowl rests cleanly, no clip
- [x] Fast upright placement — most placements clean; rare minor clip self-corrects within 0.5s
- [x] Walk away from a placed bowl — no dark seams visible at distance
- [x] Place a bowl on a lower shelf with another shelf above — no snap to upper shelf during preview
- [x] Built + installed locally as v1.1.4, ready for ModWorkshop upload after merge

## Post-merge steps

1. Tag the squash commit on main as `CatAutoFeed-v1.1.4` (annotated)
2. Force-resync staging to match new main
3. `publish.bat CatAutoFeed --version 1.1.4` (without `--no-open`) to push to ModWorkshop

🤖 Generated with [Claude Code](https://claude.com/claude-code)