### PR TITLE
CHANGELOG: trim 1.1.4 entry for ModWorkshop compatibility

### DIFF
--- a/mods/CatAutoFeed/CHANGELOG.md
+++ b/mods/CatAutoFeed/CHANGELOG.md
@@ -5,53 +5,17 @@ YYYY-MM-DD.
 
 ## 1.1.4 — 2026-04-29
 
-Bowl placement physics polish and a fix for distance-view rendering
-artifacts. Three issues addressed (#20, #22, #29). No gameplay or save
-format changes — purely visual + physics quality of life.
+Bowl placement and rendering polish. No gameplay or save changes —
+existing saves carry forward.
 
-- **Fast upright placements no longer clip the bowl into the table.** The
-  Cat Food Bowl's hollow upward-facing shape exposed an edge case in
-  vanilla physics where fast placements could spawn the bowl partially
-  below a target surface, with the rigid-body solver unable to fully
-  resolve the penetration tick-by-tick (gravity wins the contest, the
-  bowl slowly sinks deeper). Fix is a layered defence:
-  - Cylinder collision sized from the actual mesh AABB at runtime, with a
-    5% margin so it slightly overhangs the bowl rim.
-  - Wallet-style invisible proxy `MeshInstance3D` so vanilla `Placer`'s
-    `get_aabb()` query sees clean bounds rather than the GLB's raw
-    Sketchfab units.
-  - Spawn-Y correction: at `_ready()`, raycast down to find the surface
-    beneath the bowl; lift the body if vanilla Placer mis-positioned us.
-  - Pitch/roll rotation lock so the solver can't apply torque that would
-    wedge a clipped bowl deeper instead of climbing it out.
-  - Continuous in-process clip-correction: same raycast as the spawn
-    check, gated to a 0.5-second timer and run only while the bowl is
-    at rest. If the spawn correction missed and the bowl is residual-
-    drifting into a surface, lift it back up and zero linear velocity
-    so it stays put.
-  - Continuous collision detection (`continuous_cd = true`) for fast-motion
-    tunneling defence.
-- **Faint dark lines on the bowl at distance are gone.** Cause was the
-  GLB's embedded texture being imported with default S3TC compression;
-  at lower mipmap levels, the 4×4 block compression produces darker
-  pixels at UV-island boundaries (the cat-face decal edge and the
-  cylindrical wrap seam), which appear as faint dark lines once the
-  bowl is small enough on screen for the GPU to sample those mip levels.
-  No texture-filter tweak (anisotropic, etc.) masks them because the
-  dark pixels are baked into the mip data itself. Fix: set the bowl's
-  runtime material `texture_filter` to `TEXTURE_FILTER_LINEAR` (no
-  mipmaps), forcing full-resolution sampling at all distances. Mild
-  rim aliasing at distance is the trade-off; barely visible because
-  the bowl is small in screen space at that range. A cleaner fix
-  (lossless texture re-import to keep working mipmaps) is tracked
-  separately as a future polish task.
-- **Placement preview no longer snaps the bowl to nearby shelves.** A
-  regression from the clip-correction work above: while the player was
-  positioning the bowl in placement preview, the same raycast was
-  detecting nearby surfaces and lifting the bowl onto them, even when
-  the player wasn't aiming there. Fix: gate the clip-correction on
-  `freeze_mode != FREEZE_MODE_KINEMATIC` so it only runs when the bowl
-  is in the post-drop physics-active state, not during placement preview.
+- Bowls placed quickly while upright no longer clip into the surface
+  they are being placed on. Multi-layer collision detection and
+  continuous in-process correction handle all known cases.
+- Faint dark lines visible on the bowl from a few metres away are
+  gone. Mild rim aliasing at distance is the trade-off.
+- Fixed a regression in the placement preview where the bowl would
+  snap onto nearby shelves above the aim point instead of staying
+  where the player was aiming.
 
 ## 1.1.3 — 2026-04-28
 


### PR DESCRIPTION
## Summary

The original 1.1.4 CHANGELOG entry tripped ModWorkshop's spam filter on upload (HTTP 422 "changelog: contains spam content"). Their filter rules aren't public, but it's likely the combination of length, deeply nested bullets, repeated bold markdown, and technical jargon.

Replaces the long technical breakdown with a player-facing 3-bullet summary suitable for direct paste into the MW release-notes field. Detailed implementation notes still live in PR descriptions and commit messages (PR #27, #25, #29).

## Test plan

- [x] Rebuilt \`CatAutoFeed.vmz\` v1.1.4 (now 253,601 bytes; was 254,670) with the concise CHANGELOG bundled in
- [ ] User pastes the new text into MW release notes — expected to pass the spam filter

## Note on tag

The existing \`CatAutoFeed-v1.1.4\` tag points at the previous publish commit (long-changelog version). Not re-tagging since the only change is documentation text and the tag still represents the same logical release. Future releases will use the concise format from the start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)