### PR TITLE
CatAutoFeed: re-add 5mm threshold (was missing from 1.1.5 publish commit)

### DIFF
--- a/mods/CatAutoFeed/BowlPickup.gd
+++ b/mods/CatAutoFeed/BowlPickup.gd
@@ -294,7 +294,15 @@ func _compute_lift_to_clear_surface() -> float:
     # For the bowl to rest on the surface, rb_origin.y should equal
     # surface_y - _bowl_bottom_offset_y. Add 2mm so the bowl is just above.
     var desired_y := surface_y - _bowl_bottom_offset_y + 0.002
-    return max(0.0, desired_y - origin.y)
+    var lift := max(0.0, desired_y - origin.y)
+    # Skip sub-5mm corrections — the physics solver self-resolves shallow
+    # penetration tick-by-tick, and our half-second lift fights the solver
+    # when the bowl is touching another item that nudges it microscopically
+    # each tick (visible as a perceptible bump every 0.5s). Real clip-throughs
+    # that need our help (the case 1.1.4 originally addressed) are cm-scale.
+    if lift < 0.005:
+        return 0.0
+    return lift
 
 func _open_panel() -> void:
     var panel_script = load(PANEL_SCRIPT_PATH)


### PR DESCRIPTION
## Summary

Pre-publish hotfix. The 5mm sub-correction threshold guard in `BowlPickup._compute_lift_to_clear_surface` was applied locally and verified in a built \`.vmz\` during 1.1.5 development, but the source change was never staged into the commits that landed in #35. Main's CHANGELOG describes two guards (10cm rejection + 5mm threshold) but only the 10cm guard is in the code.

This PR adds the missing 5mm guard so the source matches the CHANGELOG before the \`.vmz\` is published to ModWorkshop. Version stays at 1.1.5 since the previous \`.vmz\` was never published.

## Test plan

- [x] Locally-built v1.1.4-labeled \`.vmz\` containing this code already validated by user — no bump-cycle when bowl is placed touching another item
- [x] Standard placement on flat surface still settles correctly
- [ ] Re-build at v1.1.5 after merge and confirm same behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)