### PR TITLE
Publish CatAutoFeed 1.1.7: fix Legendary tooltip + document shelter-override MCM

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This monorepo houses multiple mods, each with its own independent version. GitHu
 
 | Mod | Version | Release tag | ModWorkshop |
 |-----|---------|-------------|-------------|
-| **Cat Auto Feed** | `1.1.4` | [CatAutoFeed-v1.1.4](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/CatAutoFeed-v1.1.4) | [56407](https://modworkshop.net/mod/56407) |
+| **Cat Auto Feed** | `1.1.7` | [CatAutoFeed-v1.1.7](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/CatAutoFeed-v1.1.7) | [56407](https://modworkshop.net/mod/56407) |
 | **RTV Mod Logger** | `1.0.1` | [RTVModLogger-v1.0.1](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/RTVModLogger-v1.0.1) | [56406](https://modworkshop.net/mod/56406) |
 | **RTV Wallets** | `1.0.1` | [RTVWallets-v1.0.1](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/RTVWallets-v1.0.1) | [56408](https://modworkshop.net/mod/56408) |
 | **Punisher Guarantee** | `0.1.0` | [PunisherGuarantee-v0.1.0](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/PunisherGuarantee-v0.1.0) | — (not yet published) |

--- a/mods/CatAutoFeed/CHANGELOG.md
+++ b/mods/CatAutoFeed/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to the Cat Auto Feed mod are documented here. Dates are
 YYYY-MM-DD.
 
+## 1.1.7 — 2026-05-01
+
+- **Fix: "Bowl in Loot Tables" MCM tooltip still claimed rarity
+  Legendary.** The 1.1.6 demotion to Rare updated the item's actual
+  rarity tier but the in-game tooltip text was missed. Players hovering
+  the toggle in MCM saw "rarity Legendary, ~1 in 120 containers" — both
+  values stale. Tooltip now reads "rarity Rare" without a specific
+  spawn-rate claim (the actual ratio depends on the game's Rare-tier
+  weight in the master loot table and isn't stable to advertise).
+- **Docs: "Auto-Feed Even In Cat's Shelter" MCM toggle now documented
+  in README.** The toggle was added in 1.1.3 but never made it into
+  the README's MCM Configuration table or the Features section. Both
+  updated so players reading the README discover the override option
+  without having to dig through the in-game MCM panel.
+- No code changes beyond the tooltip string; no save format changes;
+  existing saves carry forward unchanged.
+
 ## 1.1.6 — 2026-05-01
 
 - **Bowl rarity demoted from Legendary to Rare.** Previously

--- a/mods/CatAutoFeed/PUBLISH_NOTES.md
+++ b/mods/CatAutoFeed/PUBLISH_NOTES.md
@@ -6,7 +6,7 @@ Internal workspace doc. Not bundled in the .vmz.
 
 **Publish position:** SECOND, after RTVModLogger. RTVModItemRegistry was retired (Metro v3.x's built-in registry replaces it natively); we now use Metro's `lib.register(SCENES, ...)` and `lib.register(LOOT, ...)` directly via the `[registry]` opt-in in mod.txt.
 
-**Pre-publish state:** v1.1.0 frozen. Eight MCM toggles. Metro v3.0+ hard-required (uses Metro's registry API). Logger 6/6 API coverage. Cat bowl has Sketchfab CC BY 4.0 attribution in NOTICES.txt.
+**Current state:** v1.1.7 (live on ModWorkshop as id 56407). Nine MCM toggles. Metro v3.0+ hard-required (uses Metro's registry API). Logger 6/6 API coverage. Cat bowl has Sketchfab CC BY 4.0 attribution in NOTICES.txt.
 
 ## TL;DR pitch
 
@@ -25,7 +25,7 @@ Internal workspace doc. Not bundled in the .vmz.
 | **Dependencies** | **Metro Mod Loader (#55623) v3.0.0+ required** (uses Metro's `[registry]` API); MCM (#53713) recommended |
 | **License** | MIT (mod code) + CC BY 4.0 attribution for cat bowl model — see NOTICES.txt |
 | **Description source** | Use README.md content directly. |
-| **Screenshots** | `screenshots/01_overview.png` (hero — bowl in inventory), `02_mcm.png` (8 MCM toggles), `03_cat_bowl.png` (bowl in world). |
+| **Screenshots** | `screenshots/01_overview.png` (hero — bowl in inventory), `02_mcm.png` (9 MCM toggles), `03_cat_bowl.png` (bowl in world). |
 
 ## Incompatibility callout (include in description)
 
@@ -37,8 +37,8 @@ Internal workspace doc. Not bundled in the .vmz.
 
 - [ ] **Test compatibility with Put Food Out (#56098)** — install both, document result; list as known-incompat in description if hard conflict
 - [ ] Optional: capture a 4th screenshot of the bowl in trader supply (purple Legendary badge) — strong differentiator vs Put Food Out, but the 3 existing shots are sufficient to ship
-- [ ] First publish via ModWorkshop web form
-- [ ] **Post-publish:** write assigned mod id into `mods/CatAutoFeed/.publish` AND add `[updates]\nmodworkshop=<id>` to `mod.txt`, then rebuild + re-upload so the shipped `.vmz` is update-aware
+- [x] First publish via ModWorkshop web form (mod id 56407)
+- [x] **Post-publish:** mod id `56407` written to `mods/CatAutoFeed/.publish`; `[updates] modworkshop=56407` added to `mod.txt`
 
 ## References
 

--- a/mods/CatAutoFeed/README.md
+++ b/mods/CatAutoFeed/README.md
@@ -17,7 +17,7 @@ No more returning to base every 40 minutes to drop a can of tuna in the feeder. 
 - **Auto-feed from anywhere** — when cat hunger drops below the threshold and you're outside the shelter, the cat eats one serving from its bowl. No more returning to base just to refill.
 - **Opt-in shelter-food fallback (safety net)** — if the bowl runs dry, the cat raids raw food on the floor or in cabinets/fridges in its shelter so it doesn't starve. Toggle on in MCM if you want the safety net; off by default for purist bowl-only play.
 - **Hunger and bowl-empty warnings** — orange on-screen notifications, once per hunger cycle, so you know to refill before it's a problem.
-- **Manual feeding preserved** — when you're inside the cat's shelter, the mod defers to the vanilla CatFeeder. Same UX as before.
+- **Manual feeding preserved** — when you're inside the cat's shelter, the mod defers to the vanilla CatFeeder. Same UX as before. (Optional MCM override: *Auto-Feed Even In Cat's Shelter* makes the bowl keep working at home too, for fully hands-off play.)
 - **Cat Food Bowl item** — 2x2 placeable inventory item with a custom 3D model. Sellable, droppable. Holds up to 10 servings of cat-edible food (Cat Food, Canned Meat, Canned Tuna, Perch).
 - **Bowl management panel** — middle-click a placed bowl to open a custom UI: two-column layout (bowl ↔ inventory), Take/Add buttons, capacity indicator, "Pick up bowl" button (enabled when empty).
 - **Spawns in rare loot** — the bowl is registered in the master loot table, so it can spawn in civilian containers at Rare rarity. Toggleable in MCM. Optionally the Gunsmith trader (unlocks day 10) can also stock bowls — opt-in via MCM, default off so bowls remain loot-only.
@@ -36,6 +36,7 @@ No more returning to base every 40 minutes to drop a can of tuna in the feeder. 
 | Bowl in Loot Tables | On | Adds the bowl to the master loot table at Rare rarity. Reload the game after toggling. |
 | Bowl at Gunsmith | **Off** | Lets the Gunsmith trader (day-10 unlock) stock bowls in his random supply. Off by default — bowls are loot-only out of the box. Reload the game after toggling. |
 | Cat Company Mental Buff | On | While in the cat's shelter (cat alive), raise mental at the same rate as a fire. |
+| Auto-Feed Even In Cat's Shelter | **Off** | When off, the auto-feed defers to the vanilla CatFeeder while you're inside the cat's shelter. When on, the mod keeps tickling the bowl regardless — for players who want fully hands-off feeding even when home. |
 
 Plus the standard Logger category (level, file output, overlay output). See [the RTV Mod Logger reference](https://github.com/dwoodruff83/RoadToVostokMods/blob/main/mods/RTVModLogger/LOGGER.md) for details.
 

--- a/mods/CatAutoFeed/config.gd
+++ b/mods/CatAutoFeed/config.gd
@@ -74,7 +74,7 @@ func _ready() -> void:
 
     config.set_value("Bool", "bowl_in_loot", {
         "name" = "Bowl in Loot Tables",
-        "tooltip" = "When ON (default), Cat Food Bowl is added to the master loot table so it can spawn in civilian containers (rarity Legendary, ~1 in 120 containers). Turn off if you want the bowl as a trader-only or unfindable item. Reload the game for changes to take effect.",
+        "tooltip" = "When ON (default), Cat Food Bowl is added to the master loot table so it can spawn in civilian containers (rarity Rare). Turn off if you want the bowl as a trader-only or unfindable item. Reload the game for changes to take effect.",
         "default" = true,
         "value" = true,
         "category" = "General",

--- a/mods/CatAutoFeed/mod.txt
+++ b/mods/CatAutoFeed/mod.txt
@@ -1,7 +1,7 @@
 [mod]
 name="Cat Auto Feed"
 id="CatAutoFeed"
-version="1.1.6"
+version="1.1.7"
 
 [autoload]
 CatAutoFeedLog="res://mods/CatAutoFeed/Logger.gd"


### PR DESCRIPTION
## Summary

- **Bug fix:** the "Bowl in Loot Tables" MCM tooltip still claimed `rarity Legendary, ~1 in 120 containers` after the 1.1.6 demotion to Rare. Players hovering the toggle in MCM saw stale text. Tooltip now reads `rarity Rare` (no specific spawn-rate claim — the actual ratio depends on the game's Rare-tier weight).
- **Docs catch-up:** the `Auto-Feed Even In Cat's Shelter` MCM toggle was added in 1.1.3 but never made it into the README MCM Configuration table or the Features section. Both updated.
- Workspace README mod-versions table bumped 1.1.4 → 1.1.7 (was already two versions stale).
- PUBLISH_NOTES.md cleaned up: `Pre-publish state: v1.1.0 frozen` → `Current state: v1.1.7`, "Eight MCM toggles" → "Nine", screenshot caption "8" → "9", long-since-completed post-publish TODOs checked off.
- mod.txt bumped to 1.1.7, CHANGELOG entry added.

No save format changes; existing saves carry forward unchanged.

## Test plan

- [ ] Build via `publish.bat CatAutoFeed --version 1.1.7 --no-open --install`
- [ ] Launch game; verify MCM tooltip on "Bowl in Loot Tables" reads "rarity Rare"
- [ ] Verify the "Auto-Feed Even In Cat's Shelter" toggle is still visible in MCM (no regression from docs-only changes)
- [ ] Verify a placed bowl still auto-feeds the cat from outside the shelter
- [ ] Verify save-load round-trip with an existing 1.1.6 save (no save-format changes expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)