### PR TITLE
Publish RTVModLogger 1.0.2: fix welcome_on_start fallback default

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This monorepo houses multiple mods, each with its own independent version. GitHu
 | Mod | Version | Release tag | ModWorkshop |
 |-----|---------|-------------|-------------|
 | **Cat Auto Feed** | `1.1.7` | [CatAutoFeed-v1.1.7](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/CatAutoFeed-v1.1.7) | [56407](https://modworkshop.net/mod/56407) |
-| **RTV Mod Logger** | `1.0.1` | [RTVModLogger-v1.0.1](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/RTVModLogger-v1.0.1) | [56406](https://modworkshop.net/mod/56406) |
+| **RTV Mod Logger** | `1.0.2` | [RTVModLogger-v1.0.2](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/RTVModLogger-v1.0.2) | [56406](https://modworkshop.net/mod/56406) |
 | **RTV Wallets** | `1.0.1` | [RTVWallets-v1.0.1](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/RTVWallets-v1.0.1) | [56408](https://modworkshop.net/mod/56408) |
 | **Punisher Guarantee** | `0.1.0` | [PunisherGuarantee-v0.1.0](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/PunisherGuarantee-v0.1.0) | — (not yet published) |
 

--- a/mods/RTVModLogger/CHANGELOG.md
+++ b/mods/RTVModLogger/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to the RTV Mod Logger are documented here. Dates are
 YYYY-MM-DD.
 
+## 1.0.2 — 2026-05-01
+
+- **Fix: `welcome_on_start` runtime fallback default now matches schema.**
+  In `config.gd._apply()`, the `ConfigFile.get_value()` fallback for
+  `welcome_on_start` was hardcoded to `{"value": true}` while the schema
+  (and the README MCM table) specify a default of `false`. The fallback
+  only fires if `config.ini` load fails outright (file missing or parse
+  error), so player impact in normal use was zero — but in the rare path
+  where it triggered, the welcome notification would silently fire
+  against the documented default. Now matches schema: a missing or
+  unreadable `config.ini` no longer surprises users with an unexpected
+  welcome notification at game start.
+- One literal-value flip in fallback code; no save/config file format
+  changes; existing `config.ini` files are unaffected (the fallback
+  only matters when load fails).
+
 ## 1.0.1 — 2026-04-26
 
 Re-upload to register the ModWorkshop mod id (`modworkshop=56406` in

--- a/mods/RTVModLogger/PUBLISH_NOTES.md
+++ b/mods/RTVModLogger/PUBLISH_NOTES.md
@@ -29,8 +29,8 @@ Internal workspace doc. Not bundled in the .vmz.
 
 ## Remaining TODO
 
-- [ ] First publish via ModWorkshop web form
-- [ ] **Post-publish:** write assigned mod id into `mods/RTVModLogger/.publish` AND add `[updates]\nmodworkshop=<id>` to `mod.txt`, then rebuild + re-upload so the shipped `.vmz` is update-aware (Metro Mod Loader auto-update support)
+- [x] First publish via ModWorkshop web form (mod id 56406)
+- [x] **Post-publish:** mod id `56406` written to `mods/RTVModLogger/.publish`; `[updates] modworkshop=56406` added to `mod.txt`
 
 ## References
 

--- a/mods/RTVModLogger/PUBLISH_NOTES.md
+++ b/mods/RTVModLogger/PUBLISH_NOTES.md
@@ -6,7 +6,7 @@ Internal workspace doc. Not bundled in the .vmz.
 
 **Publish position:** FIRST among the day-one releases. RTVModItemRegistry was retired (Metro v3.x's built-in registry replaces it natively), so RTVModLogger is now the lead publish, followed by CatAutoFeed.
 
-**Pre-publish state:** v1.0.0 frozen. Welcome notify defaults OFF. Build packaging includes README/CHANGELOG/LOGGER.md/LICENSE in the .vmz.
+**Current state:** v1.0.2 (live on ModWorkshop as id 56406). Welcome notify defaults OFF (and the runtime fallback now matches the schema as of 1.0.2). Build packaging includes README/CHANGELOG/LOGGER.md/LICENSE in the .vmz.
 
 **Differentiator from Metro v3.x's Developer Mode:** Metro's checkbox enables loader-internal `[ModLoader][Debug]` logs. RTVModLogger is a library other mods consume to expose *their* internals, with per-mod files, MCM toggles per consumer, and in-game overlay routing through `Loader.Message`. Different layer of the stack — they're complementary, not competing.
 

--- a/mods/RTVModLogger/config.gd
+++ b/mods/RTVModLogger/config.gd
@@ -127,7 +127,7 @@ func _apply(config: ConfigFile) -> void:
     if fresh.load(FILE_PATH + "/config.ini") == OK:
         config = fresh
 
-    welcome_on_start = bool(config.get_value("Bool", "welcome_on_start", {"value": true})["value"])
+    welcome_on_start = bool(config.get_value("Bool", "welcome_on_start", {"value": false})["value"])
     test_hotkey_keycode = int(config.get_value("Keycode", "test_hotkey", {"value": KEY_F12})["value"])
 
     var idx: int = int(config.get_value("Dropdown", "test_action", {"value": 0})["value"])

--- a/mods/RTVModLogger/mod.txt
+++ b/mods/RTVModLogger/mod.txt
@@ -1,7 +1,7 @@
 [mod]
 name="RTV Mod Logger"
 id="RTVModLogger"
-version="1.0.1"
+version="1.0.2"
 
 [autoload]
 RTVModLoggerLog="res://mods/RTVModLogger/Logger.gd"


### PR DESCRIPTION
## Summary

One-line code fix in \`config.gd\` plus PUBLISH_NOTES staleness cleanup. **No version bump in this commit** — deferred until local-build smoke test confirms the mod still loads at 1.0.1. Bump commit will follow.

- **\`config.gd\` line 130 fix:** \`_apply()\` fallback default for \`welcome_on_start\` was \`{"value": true}\` while the schema (and README MCM table) specify \`false\`. The fallback only fires if config.ini load fails outright (file missing, parse error), but in that low-probability path the welcome notification would silently fire against the documented default. Now matches schema.
- **\`PUBLISH_NOTES.md\`:** post-publish workflow checkboxes ticked off (mod has been live as 56406 since 2026-04-27).

## Test plan

- [ ] Build at current version (1.0.1): \`./publish.bat RTVModLogger --no-open\`
- [ ] Launch game; confirm RTVModLogger loads cleanly (no autoload errors in Logger output or console)
- [ ] Open MCM → RTVModLogger; verify all three settings render (Welcome on Game Start, Test Hotkey, Test Action) — no regression from the touched code path
- [ ] Optional deeper verify: delete \`%APPDATA%\Road to Vostok\MCM\RTVModLogger\config.ini\`, launch game, confirm welcome notification does NOT fire (proves the fallback now respects the schema default)

## What comes next (in this same PR)

After verification:
- Add follow-up commit on staging: bump \`mod.txt\` 1.0.1 → 1.0.2, update workspace README mod-versions table row, update PUBLISH_NOTES "Pre-publish state: v1.0.0 frozen" → "Current state: v1.0.2 (live on ModWorkshop as id 56406)", add CHANGELOG 1.0.2 entry
- Build again at 1.0.2, verify Metro picks up the auto-update mechanism
- Squash-merge staging → main, tag \`RTVModLogger-v1.0.2\`, run post-squash resync ritual

🤖 Generated with [Claude Code](https://claude.com/claude-code)