### PR TITLE
Three-mod patch: harden [registry] against Metro v3.0.0 empty-section drop

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ This monorepo houses multiple mods, each with its own independent version. GitHu
 
 | Mod | Version | Release tag | ModWorkshop |
 |-----|---------|-------------|-------------|
-| **Cat Auto Feed** | `1.1.7` | [CatAutoFeed-v1.1.7](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/CatAutoFeed-v1.1.7) | [56407](https://modworkshop.net/mod/56407) |
+| **Cat Auto Feed** | `1.1.8` | [CatAutoFeed-v1.1.8](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/CatAutoFeed-v1.1.8) | [56407](https://modworkshop.net/mod/56407) |
 | **RTV Mod Logger** | `1.0.2` | [RTVModLogger-v1.0.2](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/RTVModLogger-v1.0.2) | [56406](https://modworkshop.net/mod/56406) |
-| **RTV Wallets** | `1.0.1` | [RTVWallets-v1.0.1](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/RTVWallets-v1.0.1) | [56408](https://modworkshop.net/mod/56408) |
-| **RTV Hideout Lights** | `1.0.0` | [RTVHideoutLights-v1.0.0](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/RTVHideoutLights-v1.0.0) | [56519](https://modworkshop.net/mod/56519) |
+| **RTV Wallets** | `1.0.2` | [RTVWallets-v1.0.2](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/RTVWallets-v1.0.2) | [56408](https://modworkshop.net/mod/56408) |
+| **RTV Hideout Lights** | `1.0.1` | [RTVHideoutLights-v1.0.1](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/RTVHideoutLights-v1.0.1) | [56519](https://modworkshop.net/mod/56519) |
 | **Punisher Guarantee** | `0.1.0` | [PunisherGuarantee-v0.1.0](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/PunisherGuarantee-v0.1.0) | — (not yet published) |
 
 ## Game Info

--- a/mods/CatAutoFeed/CHANGELOG.md
+++ b/mods/CatAutoFeed/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to the Cat Auto Feed mod are documented here. Dates are
 YYYY-MM-DD.
 
+## 1.1.8 — 2026-05-02
+
+- **Fix: Cat_Bowl can fail to register on Metro Mod Loader v3.0.0.**
+  The mod's `[registry]` section in `mod.txt` had only `;`-comment lines
+  in its body, which Godot's `ConfigFile` parser strips before checking
+  for emptiness. On Metro v3.0.0 (which lacks the workaround that v3.0.1
+  added) the section was then dropped, `_any_mod_declared_registry`
+  stayed false, the Database.gd rewriter never fired, and
+  `lib.register(SCENES, "Cat_Bowl", ...)` returned false with the
+  warning "Metro rejected SCENES for Cat_Bowl". Effect: bowl wasn't in
+  `Database`, didn't appear at the Gunsmith trader, didn't spawn in
+  loot tables, and couldn't be placed. Fix is one line: added
+  `opt_in = true` under `[registry]` so the section parses on every
+  Metro version. Players already on Metro v3.0.1+ are unaffected.
+- No code changes; no save format changes; existing saves carry forward.
+- Discovered while diagnosing the same bug on RTV Hideout Lights 1.0.0.
+
 ## 1.1.7 — 2026-05-01
 
 - **Fix: "Bowl in Loot Tables" MCM tooltip still claimed rarity

--- a/mods/CatAutoFeed/mod.txt
+++ b/mods/CatAutoFeed/mod.txt
@@ -1,7 +1,7 @@
 [mod]
 name="Cat Auto Feed"
 id="CatAutoFeed"
-version="1.1.7"
+version="1.1.8"
 
 [autoload]
 CatAutoFeedLog="res://mods/CatAutoFeed/Logger.gd"
@@ -11,6 +11,9 @@ CatAutoFeed="res://mods/CatAutoFeed/Main.gd"
 [registry]
 ; Opts into Metro's registry API so Cat_Bowl is added to Database / LT_Master
 ; via lib.register() instead of take_over_path (Metro v3.x and later).
+; opt_in keeps the section non-empty so Godot's ConfigFile parser doesn't drop
+; it on Metro v3.0.0 (the workaround for empty sections only landed in v3.0.1).
+opt_in = true
 
 [updates]
 modworkshop=56407

--- a/mods/RTVHideoutLights/CHANGELOG.md
+++ b/mods/RTVHideoutLights/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to the RTV Hideout Lights mod are documented here. Dates are
 YYYY-MM-DD.
 
+## 1.0.1 — 2026-05-02
+
+- **Fix: registration silently fails on Metro Mod Loader v3.0.0.**
+  The mod's `[registry]` section in `mod.txt` was a bare header with no
+  body. Godot's `ConfigFile` parser drops empty sections, so on Metro
+  v3.0.0 (which lacks the workaround that v3.0.1 added) the section was
+  dropped and `_any_mod_declared_registry` stayed false. The Database.gd
+  rewriter never fired, `_rtv_mod_scenes` was missing on the Database
+  autoload, and all 9 SCENES registrations returned false with the
+  warning "Metro rejected SCENES for ...". Downstream effects: items
+  weren't in `Database`, the Generalist trader had nothing to stock, and
+  placement didn't work. Fix is one line: added `opt_in = true` under
+  `[registry]` so the section parses on every Metro version.
+- No code changes; no save format changes; existing saves carry forward.
+- Reported via ModWorkshop comments on mod 56519 (officialkuutti, bcav712).
+
 ## 1.0.0 — 2026-05-01
 
 First public release. Nine placeable light fixtures, stocked by all three currently-revealed traders (Generalist, Gunsmith, Doctor):

--- a/mods/RTVHideoutLights/mod.txt
+++ b/mods/RTVHideoutLights/mod.txt
@@ -1,7 +1,7 @@
 [mod]
 name="RTV Hideout Lights"
 id="RTVHideoutLights"
-version="1.0.0"
+version="1.0.1"
 
 [autoload]
 RTVHideoutLightsLog="res://mods/RTVHideoutLights/Logger.gd"
@@ -9,6 +9,7 @@ RTVHideoutLightsConfig="res://mods/RTVHideoutLights/config.gd"
 RTVHideoutLights="res://mods/RTVHideoutLights/Main.gd"
 
 [registry]
+opt_in = true
 
 [updates]
 modworkshop=56519

--- a/mods/RTVWallets/CHANGELOG.md
+++ b/mods/RTVWallets/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to the RTV Wallets mod are documented here. Dates are
 YYYY-MM-DD.
 
+## 1.0.2 — 2026-05-02
+
+- **Fix: wallet/cash items can fail to register on Metro Mod Loader
+  v3.0.0.** The mod's `[registry]` section in `mod.txt` had only
+  `;`-comment lines in its body, which Godot's `ConfigFile` parser
+  strips before checking for emptiness. On Metro v3.0.0 (which lacks
+  the workaround that v3.0.1 added) the section was then dropped,
+  `_any_mod_declared_registry` stayed false, the Database.gd rewriter
+  never fired, and `lib.register(SCENES, ...)` returned false with the
+  warning "Metro rejected SCENES for ...". Effect: wallets / cash
+  weren't in `Database`, traders had nothing to stock, lootable
+  wallets didn't spawn. Fix is one line: added `opt_in = true` under
+  `[registry]` so the section parses on every Metro version. Players
+  already on Metro v3.0.1+ are unaffected.
+- No code changes; no save format changes; existing saves carry forward.
+- Discovered while diagnosing the same bug on RTV Hideout Lights 1.0.0.
+
 ## 1.0.1 — 2026-04-26
 
 Re-upload to register the ModWorkshop mod id (`modworkshop=56408` in

--- a/mods/RTVWallets/mod.txt
+++ b/mods/RTVWallets/mod.txt
@@ -1,7 +1,7 @@
 [mod]
 name="RTV Wallets"
 id="RTVWallets"
-version="1.0.1"
+version="1.0.2"
 
 [autoload]
 RTVWalletsLog="res://mods/RTVWallets/Logger.gd"
@@ -11,6 +11,9 @@ RTVWallets="res://mods/RTVWallets/Main.gd"
 [registry]
 ; Opts into Metro's registry API so wallet/cash scenes are added to Database
 ; via lib.register() instead of take_over_path (Metro v3.x and later).
+; opt_in keeps the section non-empty so Godot's ConfigFile parser doesn't drop
+; it on Metro v3.0.0 (the workaround for empty sections only landed in v3.0.1).
+opt_in = true
 
 [updates]
 modworkshop=56408


### PR DESCRIPTION
## Summary

Patches three mods against a Metro Mod Loader v3.0.0 bug where Godot's `ConfigFile` parser silently drops empty `[registry]` sections, causing `lib.register(SCENES, ...)` to fail and the affected items to never reach `Database` (no placement, no trader stocking, no loot spawns).

| Mod | Old → New |
|---|---|
| CatAutoFeed | 1.1.7 → **1.1.8** |
| RTVWallets | 1.0.1 → **1.0.2** |
| RTVHideoutLights | 1.0.0 → **1.0.1** |

## Root cause

Metro v3.1.1's [`scenes.gd:29-31`](https://github.com/ametrocavich/vostok-mod-loader/blob/v3.1.1/src/registry/scenes.gd#L29-L31) returns false when `_rtv_mod_scenes` is missing from the Database autoload. That dict only gets injected when the Database.gd rewriter fires, which only happens when at least one loaded mod has a `[registry]` section that survives `ConfigFile` parsing.

All three of our mods declared `[registry]` with either a bare header or only `;`-comment lines as body. Godot's `ConfigFile` strips comments and drops the resulting empty section. Metro v3.0.1 added a workaround (scans raw text for `[registry]` and stashes a sentinel key), but v3.0.0 has no workaround — so on v3.0.0 our `[registry]` is silently dropped, `_any_mod_declared_registry` stays false, the rewriter never fires, and every `lib.register(SCENES, ...)` call fails.

Reported on RTV Hideout Lights by `officialkuutti` ("Metro rejected Scenes for every 9 lights") and `bcav712` ("Generalist trader has no lights"). XP/Skills mod (their shared mod-stack member) was ruled out as a direct conflict — it doesn't declare `[registry]`, doesn't touch `Database.gd`, doesn't use `lib.register`.

## Fix

One line per `mod.txt`: added `opt_in = true` under `[registry]` so the section parses on every Metro version, including v3.0.0.

No code changes. No save format changes. Existing saves carry forward unchanged on all three mods. Players already on Metro v3.0.1+ are unaffected by the bug and unaffected by the fix.

## Files changed

- `mods/CatAutoFeed/mod.txt` + `CHANGELOG.md`
- `mods/RTVWallets/mod.txt` + `CHANGELOG.md`
- `mods/RTVHideoutLights/mod.txt` + `CHANGELOG.md`
- `README.md` (mod-releases table version bumps)

## Test plan

- [x] Each `.vmz` rebuilt and locally installed via `publish.bat <Mod> --no-open`.
- [x] All three uploaded to ModWorkshop with Primary Download cleared.
- [ ] In-game smoke test: load with all three mods active on Metro v3.1.1, confirm no "Metro rejected SCENES" warnings, confirm placement / trader / loot still work end-to-end.
- [ ] Reply to officialkuutti and bcav712 on RTV Hideout Lights MW page once 1.0.1 propagates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)