### PR TITLE
Publish RTVHideoutLights 1.1.0: placement and switch routing overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This monorepo houses multiple mods, each with its own independent version. GitHu
 | **Cat Auto Feed** | `1.1.8` | [CatAutoFeed-v1.1.8](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/CatAutoFeed-v1.1.8) | [56407](https://modworkshop.net/mod/56407) |
 | **RTV Mod Logger** | `1.0.2` | [RTVModLogger-v1.0.2](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/RTVModLogger-v1.0.2) | [56406](https://modworkshop.net/mod/56406) |
 | **RTV Wallets** | `1.0.2` | [RTVWallets-v1.0.2](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/RTVWallets-v1.0.2) | [56408](https://modworkshop.net/mod/56408) |
-| **RTV Hideout Lights** | `1.0.1` | [RTVHideoutLights-v1.0.1](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/RTVHideoutLights-v1.0.1) | [56519](https://modworkshop.net/mod/56519) |
+| **RTV Hideout Lights** | `1.1.0` | [RTVHideoutLights-v1.1.0](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/RTVHideoutLights-v1.1.0) | [56519](https://modworkshop.net/mod/56519) |
 | **Punisher Guarantee** | `0.1.0` | [PunisherGuarantee-v0.1.0](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/PunisherGuarantee-v0.1.0) | — (not yet published) |
 
 ## Game Info

--- a/mods/RTVHideoutLights/CHANGELOG.md
+++ b/mods/RTVHideoutLights/CHANGELOG.md
@@ -3,20 +3,20 @@
 All notable changes to the RTV Hideout Lights mod are documented here. Dates are
 YYYY-MM-DD.
 
+## 1.1.0 — 2026-05-04
+
+Placement and switch-routing overhaul. No save format changes; existing saves carry forward.
+
+- **Placement preview now works on every fixture.** Earlier versions left the lit lamp/screen visible inside the green hologram and skipped the hologram material on switch-controlled fixtures. The new lifecycle hides Light3D / emissive Bulb meshes during preview without mutating toggle state, and only commits the off-state after placement so the hologram renders cleanly.
+- **Pickup resets to off; placement syncs to the room switch.** Picking up any fixture turns it off for the move (clean preview, predictable state). When you commit placement: switch-controlled fixtures (Cellar Wall Light, all Fluorescents) immediately match the nearest room switch's on/off state. Manual fixtures (Floor Lamp, PC, Candle, Lantern) stay off so the player turns them on with Use.
+- **Smart room-aware switch routing.** Multi-switch shelters like the Cabin have one switch per room. Placed fixtures now subscribe to the switch whose existing static lights are nearest, NOT just whichever switch enumerates first. Re-placing a fixture in a different room drops the old subscription and joins the new one, so a fixture is only ever wired to one switch. The "nearest static light" heuristic can occasionally mis-assign on edge cases (a fixture placed in a doorway between two rooms, or two switches whose lights are nearly equidistant); pick up and re-place to nudge it.
+- **Interaction collider now covers the full fixture height.** The box collider was centered at scene origin instead of the AABB center, which on tall fixtures like the Floor Lamp meant the upper half (lampshade) was outside the interaction volume. Aiming at the lampshade now triggers the Use prompt.
+- **Hardened against catalog-pickup crash.** When a placed switch-controlled fixture was picked back up to the catalog, the switch's `targets` array kept the freed reference. The next switch toggle called `Deactivate()` on a dead object and crashed the game. LightToggle now removes itself from the switch on `_exit_tree`, and Activate/Deactivate use `is_instance_valid()` checks so stale node references no-op instead of crashing.
+
 ## 1.0.1 — 2026-05-02
 
-- **Fix: registration silently fails on Metro Mod Loader v3.0.0.**
-  The mod's `[registry]` section in `mod.txt` was a bare header with no
-  body. Godot's `ConfigFile` parser drops empty sections, so on Metro
-  v3.0.0 (which lacks the workaround that v3.0.1 added) the section was
-  dropped and `_any_mod_declared_registry` stayed false. The Database.gd
-  rewriter never fired, `_rtv_mod_scenes` was missing on the Database
-  autoload, and all 9 SCENES registrations returned false with the
-  warning "Metro rejected SCENES for ...". Downstream effects: items
-  weren't in `Database`, the Generalist trader had nothing to stock, and
-  placement didn't work. Fix is one line: added `opt_in = true` under
-  `[registry]` so the section parses on every Metro version.
-- No code changes; no save format changes; existing saves carry forward.
+- **Fix: registration silently fails on Metro Mod Loader v3.0.0.** The mod's `[registry]` section in `mod.txt` was a bare header with no body. Godot's `ConfigFile` parser drops empty sections, so on Metro v3.0.0 (which lacks the workaround that v3.0.1 added) the section was dropped and the registry opt-in was never seen. Database wasn't rewritten, all 9 SCENES registrations returned false with "Metro rejected SCENES for ...", items weren't in `Database`, and traders had nothing to stock. Fix: added `opt_in = true` under `[registry]` so the section parses on every Metro version.
+- No code or save format changes; existing saves carry forward.
 - Reported via ModWorkshop comments on mod 56519 (officialkuutti, bcav712).
 
 ## 1.0.0 — 2026-05-01

--- a/mods/RTVHideoutLights/LightFurniture.gd
+++ b/mods/RTVHideoutLights/LightFurniture.gd
@@ -3,13 +3,25 @@ extends Furniture
 # Furniture subclass for light fixtures. Two behaviours on top of vanilla
 # Furniture:
 #
-# 1. Placement-preview suppression — when the player picks the lamp up to
-#    move it (StartMove), every Light3D descendant AND any "Bulb" decoration
-#    mesh is hidden so the unplaced lamp doesn't bleed light into the room
-#    or show a bright emissive sphere inside the green placement hologram.
-#    Restored on ResetMove. The cancel-to-catalog path
-#    (Catalog -> owner.queue_free) needs no handling — the whole scene is
-#    freed.
+# 1. Placement lifecycle — when the player picks the fixture up to move
+#    it (StartMove) we force it OFF: call the toggle's Deactivate (or
+#    Fire.Deactivate) so active=false AND hide every Light3D descendant
+#    plus any "Bulb" decoration mesh so they don't leak light or show
+#    inside the green placement hologram. The fixture stays off through
+#    placement.
+#
+#    When the player commits placement (ResetMove) we route by spec:
+#      - Switch-controlled fixtures (LightToggle.subscribe_to_switch=true,
+#        the four ceiling/Cellar SKUs) re-run their switch subscription so
+#        their state matches the shelter's vanilla Light_Switch.
+#      - Manual fixtures (Floor Lamp, PC) stay off; player turns them on
+#        with the Use action.
+#      - Fire fixtures (Candle, Lantern) stay off; player ignites with Use.
+#      - Always-on fixtures with no toggle (Exit Sign) restore preview
+#        visibility so they re-light themselves.
+#
+#    The cancel-to-catalog path (Catalog -> owner.queue_free) needs no
+#    handling — the whole scene is freed.
 #
 # 2. Surface-orientation gate — when `ceiling_only = true`, placement is
 #    rejected if the center ray's hit surface normal points more "up" than
@@ -28,11 +40,14 @@ extends Furniture
 
 var _preview_hidden: Array[Node3D] = []
 
-func _ready() -> void:
-    super()
-    if Engine.is_editor_hint():
+# Lazy collection: don't walk the tree during _ready (sibling-subtree
+# ordering with the LightToggle script on the scene root made the array
+# end up empty in some catalog-spawn paths, causing StartMove's hide call
+# to no-op). Walk on first StartMove instead — by then the tree is fully
+# constructed and Placer has just called us.
+func _ensure_preview_hidden_collected() -> void:
+    if !_preview_hidden.is_empty():
         return
-    _preview_hidden.clear()
     _collect_preview_hidden_into(_preview_hidden, owner)
 
 func _collect_preview_hidden_into(out: Array[Node3D], node: Node) -> void:
@@ -47,11 +62,41 @@ func _collect_preview_hidden_into(out: Array[Node3D], node: Node) -> void:
 
 func StartMove() -> void:
     super()
+    _ensure_preview_hidden_collected()
+    # Only hide the preview-visible nodes (Light3D + Bulb). Don't call
+    # Deactivate here — it would re-apply the swap material to swap_mesh,
+    # overwriting the green hologram that vanilla super.StartMove() just
+    # set on the same surface. The fixture LOOKS off during placement
+    # because Light3D nodes are hidden; we'll commit the actual off-state
+    # in ResetMove after super.ResetMove restores sourceMaterials.
     _set_preview_visible(false)
 
 func ResetMove() -> void:
     super()
-    _set_preview_visible(true)
+    var root = owner
+    if root == null:
+        _set_preview_visible(true)
+        return
+
+    # Force the fixture off after placement (user-spec'd: "off when
+    # placed"). super.ResetMove just restored sourceMaterials including
+    # the LIT swap variant where applicable, so we re-apply Deactivate to
+    # put the swap surface back to the off material AND hide lights.
+    if root.has_method("Deactivate"):
+        root.Deactivate()
+
+    # Switch-controlled fixtures (Cellar, Industrial/Bright/Soft Fluo)
+    # immediately re-sync to the shelter's vanilla Light_Switch via the
+    # subscription path, which calls Activate or Deactivate to match.
+    if "subscribe_to_switch" in root and root.subscribe_to_switch \
+            and root.has_method("_try_subscribe_to_switch"):
+        root._try_subscribe_to_switch()
+        return
+
+    # No toggle and no fire (Exit Sign): restore preview visibility so
+    # the always-on light re-illuminates the scene.
+    if "active" not in root:
+        _set_preview_visible(true)
 
 func _set_preview_visible(value: bool) -> void:
     for n in _preview_hidden:

--- a/mods/RTVHideoutLights/LightToggle.gd
+++ b/mods/RTVHideoutLights/LightToggle.gd
@@ -58,6 +58,13 @@ extends Node3D
 var active: bool = false
 var gameData = preload("res://Resources/GameData.tres")
 
+# Cached ref to the switch we subscribed to so _exit_tree can deregister
+# in O(1). If the player picks the fixture back up to the catalog, our
+# scene root gets queue_freed — without this cleanup, the switch's
+# targets array would hold a dead reference and the next toggle would
+# crash the game on dead.Deactivate().
+var _subscribed_switch: Node = null
+
 func _ready() -> void:
     if Engine.is_editor_hint():
         return
@@ -85,23 +92,23 @@ func Interact() -> void:
 func Activate() -> void:
     active = true
     for n in lights:
-        if n:
+        if is_instance_valid(n):
             n.visible = true
     for n in lit_meshes:
-        if n:
+        if is_instance_valid(n):
             n.visible = true
-    if swap_mesh and swap_on_material:
+    if is_instance_valid(swap_mesh) and swap_on_material:
         swap_mesh.set_surface_override_material(swap_surface_index, swap_on_material)
 
 func Deactivate() -> void:
     active = false
     for n in lights:
-        if n:
+        if is_instance_valid(n):
             n.visible = false
     for n in lit_meshes:
-        if n:
+        if is_instance_valid(n):
             n.visible = false
-    if swap_mesh and swap_off_material:
+    if is_instance_valid(swap_mesh) and swap_off_material:
         swap_mesh.set_surface_override_material(swap_surface_index, swap_off_material)
 
 func UpdateTooltip() -> void:
@@ -110,26 +117,92 @@ func UpdateTooltip() -> void:
     gameData.tooltip = "%s [%s]" % [label, "Turn Off" if active else "Turn On"]
 
 func _try_subscribe_to_switch() -> void:
-    # Find any node in the "Switch" group in the active scene tree and
-    # append self to its targets array. Vanilla shelter scenes typically
-    # have at most one Switch, so we just take the first match. Then sync
-    # our visible state to the switch's current state — necessary on save
-    # load: the switch persists its `active` flag across saves, but our
-    # `force_on=true` _ready leaves the light on regardless. Without the
-    # else-Deactivate branch the player sees lights-on / switch-off after
-    # every load until they manually toggle the switch.
+    # Find the NEAREST node in the "Switch" group (by world distance to
+    # this fixture) and append self to its targets array. Multi-switch
+    # shelters like the Cabin have one switch per room — picking the
+    # closest one means a placed fixture joins the room's switch instead
+    # of always grabbing whichever switch enumerates first.
+    #
+    # Then sync our visible state to the switch's current state —
+    # necessary on save load: the switch persists its `active` flag
+    # across saves, but our `force_on=true` _ready leaves the light on
+    # regardless. Without the else-Deactivate branch the player would
+    # see lights-on / switch-off after every load until they manually
+    # toggle the switch.
+    #
+    # Skip while the fixture is in placement preview (Furniture.isMoving).
+    # The initial _ready 0.5s timer would otherwise fire mid-placement and
+    # call Activate, overwriting the hologram material set by
+    # Furniture.StartMove(). LightFurniture.ResetMove() re-invokes us once
+    # placement is committed, so the subscription still happens — just
+    # after the fixture has landed.
+    var furniture = get_node_or_null("Furniture")
+    if furniture and "isMoving" in furniture and furniture.isMoving:
+        return
+
+    # Drop any prior subscription so a re-placement (move from one room
+    # to another) doesn't end up controlled by both rooms' switches.
+    if is_instance_valid(_subscribed_switch):
+        if "targets" in _subscribed_switch and _subscribed_switch.targets is Array:
+            _subscribed_switch.targets.erase(self)
+        _subscribed_switch = null
+
+    # Pick the switch whose existing targets are nearest to us, NOT just
+    # the nearest switch by straight-line distance. Vanilla shelters
+    # (multi-room ones like the Cabin) put each switch's controlled
+    # lights in that switch's room. So "nearest target distance"
+    # functionally answers "which room am I in" — without needing to do
+    # actual navmesh pathfinding or raycast wall-checking. A switch that's
+    # physically close but mounted on a shared wall (so its lights are in
+    # the OTHER room) won't win over a switch whose lights are in our room.
+    #
+    # Fallback: if a switch has no targets yet, score it by its own
+    # position. This happens for shelters with one switch per room and
+    # we're the first fixture being added.
     var switches = get_tree().get_nodes_in_group("Switch")
+    var nearest: Node3D = null
+    var nearest_dist_sq := INF
     for node in switches:
         if not ("targets" in node):
             continue
         if not (node.targets is Array):
             continue
-        if node.targets.has(self):
-            return
-        node.targets.append(self)
-        if "active" in node:
-            if node.active:
-                Activate()
-            else:
-                Deactivate()
+        if not (node is Node3D):
+            continue
+        var switch_score := INF
+        for target in node.targets:
+            if target == self:
+                continue
+            if not is_instance_valid(target) or not (target is Node3D):
+                continue
+            var td := global_position.distance_squared_to(target.global_position)
+            if td < switch_score:
+                switch_score = td
+        if switch_score == INF:
+            # Switch has no valid targets to anchor by — use its own position.
+            switch_score = global_position.distance_squared_to(node.global_position)
+        if switch_score < nearest_dist_sq:
+            nearest_dist_sq = switch_score
+            nearest = node
+
+    if nearest == null:
         return
+
+    nearest.targets.append(self)
+    _subscribed_switch = nearest
+    if "active" in nearest:
+        if nearest.active:
+            Activate()
+        else:
+            Deactivate()
+
+# Remove ourselves from the switch's targets array when leaving the tree
+# (e.g. picked up back to catalog → owner.queue_free → all children exit
+# the tree). Without this, the switch would call .Deactivate() on a
+# dangling reference next toggle and the game crashes.
+func _exit_tree() -> void:
+    if not is_instance_valid(_subscribed_switch):
+        return
+    if "targets" in _subscribed_switch and _subscribed_switch.targets is Array:
+        _subscribed_switch.targets.erase(self)
+    _subscribed_switch = null

--- a/mods/RTVHideoutLights/PUBLISH_NOTES.md
+++ b/mods/RTVHideoutLights/PUBLISH_NOTES.md
@@ -4,7 +4,9 @@ Internal workspace doc. Not bundled in the .vmz.
 
 ## Status
 
-**Pre-publish state:** v1.0.0. Nine placeable light fixtures, stocked by all three currently-revealed traders (Generalist, Gunsmith, Doctor). Grandma intentionally skipped (still story-hidden). Metro v3.0+ hard-required (uses `[registry]` API). MCM optional (only the Logger category attaches; mod has no settings of its own). All assets are vanilla `res://Assets/...` references — the mod ships zero mesh/texture data, only trader-catalog icons and a handful of `.tscn` / `.tres` wrappers + `.gd` scripts.
+**Current state:** v1.1.0 (about to publish). Live on ModWorkshop as id 56519. v1.0.1 (live) hardened the `[registry]` section to survive Metro v3.0.0 ConfigFile parsing. v1.1.0 ships placement-preview cleanup, "off-on-pickup, sync-to-switch-on-drop" lifecycle, and room-aware switch routing (subscribes to whichever switch's static lights are nearest, so multi-room shelters like the Cabin work correctly).
+
+Nine placeable light fixtures, stocked by all three currently-revealed traders (Generalist, Gunsmith, Doctor). Grandma intentionally skipped (still story-hidden). Metro v3.0+ hard-required (uses `[registry]` API). MCM optional (only the Logger category attaches; mod has no settings of its own). All assets are vanilla `res://Assets/...` references; the mod ships zero mesh/texture data, only trader-catalog icons and a handful of `.tscn` / `.tres` wrappers + `.gd` scripts.
 
 ## TL;DR pitch
 
@@ -23,15 +25,15 @@ Internal workspace doc. Not bundled in the .vmz.
 | **Description source** | Use README.md content directly. |
 | **Screenshots** | TODO: capture before publishing — see "Screenshots to capture" below. |
 
-## Screenshots to capture
+## Screenshots (in `screenshots/`, ordered for MW)
 
-Aim for 4-5 hero shots:
-
-1. **Trader catalog** — Generalist supply page showing the row of light icons.
-2. **Hideout interior, lights on** — wide shot of a shelter with several fixtures placed and lit (cabin attic with the bright fluorescent + cellar wall sconce works well).
-3. **Same scene, switch off** — same angle, vanilla light switch flipped, all wired fixtures dark. Demonstrates switch integration.
-4. **PC + Floor Lamp close-ups** — show the cyan-lit monitor and the warm bulb glow inside the floor-lamp shade.
-5. *(optional)* **Candle + Lantern lit in the dark** — shows the ignite/extinguish behavior and warm flicker light.
+- `01_overview.png` — hero: hideout with multiple fixtures placed and lit
+- `02_mcm.png` — MCM page (Logger category only, since mod has no settings)
+- `03_catalog.png` — trader catalog row of light icons
+- `04_placement01.png` — wall placement preview (green hologram on rocky wall)
+- `05_placement02.png` — ceiling placement preview (long fluorescent tube hologram)
+- `06-interactions01.png` — lit lantern close-up (Fire integration)
+- `07-interactions02.png` — Use prompt on a fixture in a dark room
 
 ## Conflict callout (include in description)
 
@@ -39,13 +41,18 @@ Aim for 4-5 hero shots:
 - **Mods that override `res://Scripts/Switch.gd` differently** — wiring relies on Switch.gd's `targets: Array[Node3D]` field and `Activate()`/`Deactivate()` methods. A mod that swaps out Switch.gd would need to preserve that interface.
 - **Uninstall warning** — placed fixtures vanish from saves on next load if the .vmz is removed (Godot can't resolve `res://mods/RTVHideoutLights/...` paths). Pick everything up before uninstalling.
 
-## TODO before publish
+## Per-release publish steps (recurring)
 
-- [ ] Re-run `modworkshop.bat search lamp` / `light` / `placeable` to confirm no new direct competitors appeared since 2026-04-28
-- [ ] Capture the screenshot set above (save under `screenshots/`, naming convention: `01_trader.png`, `02_hideout_lit.png`, etc.)
-- [ ] Final test on a clean profile with only Metro + this mod installed
-- [ ] First publish via ModWorkshop web form
-- [ ] **Post-publish:** write assigned mod id into `mods/RTVHideoutLights/.publish` AND add `[updates]\nmodworkshop=<id>` to `mod.txt`, then rebuild + re-upload so the shipped `.vmz` is update-aware (per workspace memory: also click **Clear Primary Download** on every file swap or Metro auto-update breaks)
+For every new version after 1.0.0:
+
+- [x] Bump `mod.txt` version via `publish.bat <Mod> --version X.Y.Z --no-open` (also rebuilds + installs)
+- [x] Update CHANGELOG with the new version's entry (placement at top)
+- [x] Update README if user-facing behavior changed
+- [ ] Commit + push, PR staging → main, squash-merge
+- [ ] Tag `RTVHideoutLights-vX.Y.Z` against the merge commit on `main`
+- [ ] Post-squash resync: force-reset `staging` to `origin/main`
+- [ ] Bump workspace README releases-table row to new version
+- [ ] On ModWorkshop edit page (`publish.bat RTVHideoutLights` opens it via `.publish`): drop new `.vmz`, click **Clear Primary Download** so Metro auto-update sees the new file, save
 
 ## References
 

--- a/mods/RTVHideoutLights/README.md
+++ b/mods/RTVHideoutLights/README.md
@@ -31,9 +31,21 @@ Every fixture is stocked by all three currently-revealed traders (Generalist, Gu
 
 ## Switch integration
 
-Shelters with a vanilla **Light_Switch** (Cabin, Bunker, Classroom) already control their built-in lights. Place any fixture marked "Shelter switch" above and the mod auto-subscribes it within a fraction of a second. It turns on and off alongside the vanilla lights.
+Shelters with a vanilla **Light_Switch** (Cabin, Bunker, Classroom) already control their built-in lights. Place any fixture marked "Shelter switch" above and the mod auto-subscribes it to the room's switch.
 
-Shelters without a switch (Tent, Attic): wired fixtures still light up; there's just nothing to flip them off with. The Floor Lamp, PC, Candle, Lantern, and Exit Sign are independent of the switch in any shelter.
+**Multi-switch shelters** (the Cabin has one switch per room): the mod picks the switch whose existing static lights are nearest to your placed fixture. That's effectively "which room am I in", without needing line-of-sight or pathfinding tricks. Re-placing the fixture in a different room drops the old subscription and joins the new one.
+
+The nearest-light heuristic can mis-assign on edge cases, like a fixture placed in a doorway between two rooms or next to a switch that's mounted on a shared wall. If the fixture wires to the wrong switch, just pick it up and re-place a step further into the room you want.
+
+Shelters without a switch (Tent, Attic) leave wired fixtures permanently on; there's nothing to flip them off with. The Floor Lamp, PC, Candle, Lantern, and Exit Sign are independent of the switch in any shelter.
+
+## Placement and state
+
+Picking a fixture up to move it always turns it off for the duration of the placement preview, so the green hologram renders cleanly and the fixture lands in a known state. On commit:
+
+- **Switch-controlled fixtures** sync to the nearest room switch's current on/off state.
+- **Manual fixtures** (Floor Lamp, PC, Candle, Lantern) start off; player turns them on with Use.
+- **Always-on fixtures** (Exit Sign) light back up.
 
 When a fixture is off, both the Light3D source and the emissive lampshade material go dark (same pattern as the vanilla cabin pendants).
 

--- a/mods/RTVHideoutLights/mod.txt
+++ b/mods/RTVHideoutLights/mod.txt
@@ -1,7 +1,7 @@
 [mod]
 name="RTV Hideout Lights"
 id="RTVHideoutLights"
-version="1.0.1"
+version="1.1.0"
 
 [autoload]
 RTVHideoutLightsLog="res://mods/RTVHideoutLights/Logger.gd"

--- a/mods/RTVHideoutLights/scenes/Lamp_Cellar_Ceiling_F.tscn
+++ b/mods/RTVHideoutLights/scenes/Lamp_Cellar_Ceiling_F.tscn
@@ -57,6 +57,7 @@ script = ExtResource("3")
 surface = "Metal"
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Collider_R/StaticBody3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.0, 0.0, 0.064)
 shape = SubResource("BoxShape3D_collider")
 
 [node name="Light" type="OmniLight3D" parent="Mesh"]

--- a/mods/RTVHideoutLights/scenes/rtvlights_candle_F.tscn
+++ b/mods/RTVHideoutLights/scenes/rtvlights_candle_F.tscn
@@ -55,6 +55,7 @@ script = ExtResource("3")
 surface = "Metal"
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Collider_R/StaticBody3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.0, 0.052, 0.0)
 shape = SubResource("BoxShape3D_collider")
 
 [node name="VFX" type="GPUParticles3D" parent="."]

--- a/mods/RTVHideoutLights/scenes/rtvlights_computer_lit_F.tscn
+++ b/mods/RTVHideoutLights/scenes/rtvlights_computer_lit_F.tscn
@@ -59,6 +59,7 @@ script = ExtResource("3")
 surface = "Generic"
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Collider_R/StaticBody3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.01994950000000001, 0.27440600000000004, 0.005686499999999983)
 shape = SubResource("BoxShape3D_collider")
 
 [node name="Light" type="OmniLight3D" parent="Mesh"]

--- a/mods/RTVHideoutLights/scenes/rtvlights_lamp_floor_F.tscn
+++ b/mods/RTVHideoutLights/scenes/rtvlights_lamp_floor_F.tscn
@@ -65,6 +65,7 @@ script = ExtResource("3")
 surface = "Wood"
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Collider_R/StaticBody3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.0, 1.0, 0.0)
 shape = SubResource("BoxShape3D_collider")
 
 [node name="Light" type="SpotLight3D" parent="Mesh"]

--- a/mods/RTVHideoutLights/scenes/rtvlights_lamp_generic_lit_hp_ceiling_F.tscn
+++ b/mods/RTVHideoutLights/scenes/rtvlights_lamp_generic_lit_hp_ceiling_F.tscn
@@ -57,6 +57,7 @@ script = ExtResource("3")
 surface = "Metal"
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Collider_R/StaticBody3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.0, 0.0, 0.05)
 shape = SubResource("BoxShape3D_collider")
 
 [node name="Light" type="SpotLight3D" parent="Mesh"]

--- a/mods/RTVHideoutLights/scenes/rtvlights_lamp_generic_lit_lp_ceiling_F.tscn
+++ b/mods/RTVHideoutLights/scenes/rtvlights_lamp_generic_lit_lp_ceiling_F.tscn
@@ -57,6 +57,7 @@ script = ExtResource("3")
 surface = "Metal"
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Collider_R/StaticBody3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.0, 0.0, 0.05)
 shape = SubResource("BoxShape3D_collider")
 
 [node name="Light" type="SpotLight3D" parent="Mesh"]

--- a/mods/RTVHideoutLights/scenes/rtvlights_lamp_grid_lit_ceiling_F.tscn
+++ b/mods/RTVHideoutLights/scenes/rtvlights_lamp_grid_lit_ceiling_F.tscn
@@ -57,6 +57,7 @@ script = ExtResource("3")
 surface = "Metal"
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Collider_R/StaticBody3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.0, 0.0, 0.065)
 shape = SubResource("BoxShape3D_collider")
 
 [node name="Light" type="SpotLight3D" parent="Mesh"]

--- a/mods/RTVHideoutLights/scenes/rtvlights_lantern_kerosene_F.tscn
+++ b/mods/RTVHideoutLights/scenes/rtvlights_lantern_kerosene_F.tscn
@@ -57,6 +57,7 @@ script = ExtResource("3")
 surface = "Metal"
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Collider_R/StaticBody3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.0, 0.151361, -4.9999999999980616e-06)
 shape = SubResource("BoxShape3D_collider")
 
 [node name="VFX" type="GPUParticles3D" parent="."]

--- a/mods/RTVHideoutLights/scenes/rtvlights_sign_exit_lit_F.tscn
+++ b/mods/RTVHideoutLights/scenes/rtvlights_sign_exit_lit_F.tscn
@@ -44,6 +44,7 @@ script = ExtResource("3")
 surface = "Generic"
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Collider_R/StaticBody3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.0, 0.0, 0.06)
 shape = SubResource("BoxShape3D_collider")
 
 [node name="Light" type="SpotLight3D" parent="Mesh"]

--- a/tools/generate_lights_skus.py
+++ b/tools/generate_lights_skus.py
@@ -872,6 +872,7 @@ script = ExtResource("3")
 surface = "{surface}"
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Collider_R/StaticBody3D"]
+transform = {transform3d(1, 0, 0, 0, 1, 0, 0, 0, 1, cx, cy, cz)}
 shape = SubResource("BoxShape3D_collider")
 {light_block}{uplight_block}{bulb_node_block}{fire_vfx_block}
 [node name="Furniture" type="Node3D" parent="." node_paths=PackedStringArray("mesh", "colliderR")]


### PR DESCRIPTION
## Summary

v1.1.0 builds on the v1.0.1 [registry] hardening (#48). Tonight's behavior overhaul:

### Placement preview now renders cleanly on every fixture

The PC, Floor Lamp, ceiling fluorescents, and Cellar Wall Light all show the green hologram during placement preview. The new lifecycle hides Light3D / emissive Bulb meshes during preview without mutating toggle state, so vanilla `Furniture.StartMove`'s material override survives and the toggle's swap material isn't re-applied mid-preview.

### Pickup forces fixture off; placement re-syncs

- **Switch-controlled** (Cellar, Industrial / Bright / Soft Fluorescent): match the room switch's current state on placement
- **Manual** (Floor Lamp, PC, Candle, Lantern): stay off; player turns on with Use
- **Always-on** (Exit Sign): light back up

### Smart room-aware switch routing

Subscribes to whichever switch's existing static lights are nearest to the placed fixture. Multi-room shelters like the Cabin route fixtures to the correct room's switch instead of the first-enumerated one. Re-placing in another room drops the old subscription and joins the new one.

Caveat: the nearest-light heuristic can mis-assign on edge cases (doorways, switches mounted on shared walls). Pick up + re-place to nudge.

### Interaction collider centered at AABB center

Was at scene origin, which on tall fixtures like the Floor Lamp meant the upper half (lampshade) was outside the interaction volume. Aiming at the lampshade now triggers the Use prompt.

### Hardened against catalog-pickup crash

`LightToggle._exit_tree` removes self from `switch.targets` so picking a fixture back to the catalog no longer leaves a dead reference. Without this, the next switch toggle called `Deactivate` on a freed object and crashed the game. `Activate`/`Deactivate` also gained `is_instance_valid()` checks for stale node refs.

## Files

- `mods/RTVHideoutLights/mod.txt` — version `1.0.1` → `1.1.0`
- `mods/RTVHideoutLights/CHANGELOG.md` — added 1.1.0 entry above existing 1.0.1 + 1.0.0
- `mods/RTVHideoutLights/README.md` — refreshed Switch Integration section with multi-switch routing + caveat; added new Placement and State section
- `mods/RTVHideoutLights/PUBLISH_NOTES.md` — moved from pre-publish to post-publish state, added per-release recurring checklist
- `mods/RTVHideoutLights/LightFurniture.gd` — placement-lifecycle rewrite (StartMove hides preview only; ResetMove forces off + re-subscribes if switch-controlled)
- `mods/RTVHideoutLights/LightToggle.gd` — nearest-room switch routing, `_exit_tree` cleanup, `is_instance_valid()` hardening
- `tools/generate_lights_skus.py` — emit centered CollisionShape3D transform for the Interactable box
- `mods/RTVHideoutLights/scenes/*.tscn` — all 9 fixture scenes regenerated
- `README.md` (workspace) — releases-table row `1.0.1` → `1.1.0`

## Test plan

- [x] Catalog place a Floor Lamp: green hologram during preview, lands as OFF, "Turn On" prompt works
- [x] Catalog place a PC: hologram on body AND screen during preview, lands with dark monitor, Use turns it on (cyan UI + soft glow)
- [x] Place a Cellar Wall Light in a Cabin room with switch ON: lights up immediately
- [x] Place a Cellar Wall Light in another Cabin room with switch OFF: stays dark
- [x] Toggle a room's switch in the Cabin: only that room's wired fixtures (vanilla + ours) flip; other rooms unaffected
- [x] Pickup a placed wired fixture and put it in a different room: new room's switch controls it; old room's switch no longer does
- [x] Pickup a placed fixture back to the catalog; toggle the switch: no crash (`LightToggle._exit_tree` deregistered)
- [x] Aim at a Floor Lamp's lampshade: Use prompt appears (was previously only triggering on the lower half of the pole)

## Post-merge

- [ ] Tag `RTVHideoutLights-v1.1.0` against the merge commit
- [ ] Force-reset `staging` to `origin/main`
- [ ] ModWorkshop edit page (id 56519): drop new .vmz, click **Clear Primary Download**, save
- [ ] Reply to officialkuutti and bcav712 on MW comment thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)