### PR TITLE
RTVWallets 1.1.0: fix cash duplication via shared SlotData

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This monorepo houses multiple mods, each with its own independent version. GitHu
 |-----|---------|-------------|-------------|
 | **Cat Auto Feed** | `1.1.8` | [CatAutoFeed-v1.1.8](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/CatAutoFeed-v1.1.8) | [56407](https://modworkshop.net/mod/56407) |
 | **RTV Mod Logger** | `1.0.2` | [RTVModLogger-v1.0.2](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/RTVModLogger-v1.0.2) | [56406](https://modworkshop.net/mod/56406) |
-| **RTV Wallets** | `1.0.2` | [RTVWallets-v1.0.2](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/RTVWallets-v1.0.2) | [56408](https://modworkshop.net/mod/56408) |
+| **RTV Wallets** | `1.1.0` | [RTVWallets-v1.1.0](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/RTVWallets-v1.1.0) | [56408](https://modworkshop.net/mod/56408) |
 | **RTV Hideout Lights** | `1.1.0` | [RTVHideoutLights-v1.1.0](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/RTVHideoutLights-v1.1.0) | [56519](https://modworkshop.net/mod/56519) |
 | **Punisher Guarantee** | `0.1.0` | [PunisherGuarantee-v0.1.0](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/PunisherGuarantee-v0.1.0) | — (not yet published) |
 

--- a/mods/RTVWallets/Ammo_Tin.tscn
+++ b/mods/RTVWallets/Ammo_Tin.tscn
@@ -7,6 +7,7 @@
 [ext_resource type="PhysicsMaterial" path="res://Items/Physics/Item_Physics.tres" id="5"]
 
 [sub_resource type="Resource" id="Resource_slot"]
+resource_local_to_scene = true
 script = ExtResource("4")
 itemData = ExtResource("3")
 

--- a/mods/RTVWallets/CHANGELOG.md
+++ b/mods/RTVWallets/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to the RTV Wallets mod are documented here. Dates are
 YYYY-MM-DD.
 
+## 1.1.0 — 2026-05-09
+
+- **Fix: cash duplication exploit on multiple wallets of the same tier
+  (#50, reported by ppfota).** Every wallet `.tscn` declared its
+  `SlotData` SubResource without `resource_local_to_scene = true`, so
+  every spawned instance of the same tier shared the SAME SlotData
+  object reference. Filling one wallet visually filled all the others
+  too; reload + unload returned the cash for each, doubling the player's
+  money per duplicate. Fix has two parts:
+  - `Leather_Wallet.tscn`, `Ammo_Tin.tscn`, `Money_Case.tscn`, and
+    `Cash.tscn` all set `resource_local_to_scene = true` on their
+    SlotData SubResource. Fresh placements now have unique SlotData.
+  - `WalletPickup._ready` adds a one-shot heal: any wallet loaded from
+    a save written before this fix has its shared SlotData duplicated
+    so existing saves are repaired transparently on next load.
+  Same root cause + same shape of fix as Cat Bowl 1.1.0. No save
+  format changes; existing 1.0.2 saves carry forward.
+- **Docs: known incompatibility with Oldman's Immersive Overhaul (v3.0.3 and earlier)** noted in README. The two mods integrate with Metro through different patterns and don't currently compose — Oldman's pre-`[registry]` Database-replacement overrides cause our wallets and cash to silently fail to load. Pending Metro v3 update on Oldman's side; workaround is to run one or the other, not both.
+
 ## 1.0.2 — 2026-05-02
 
 - **Fix: wallet/cash items can fail to register on Metro Mod Loader

--- a/mods/RTVWallets/Cash.tscn
+++ b/mods/RTVWallets/Cash.tscn
@@ -8,6 +8,7 @@
 [ext_resource type="PhysicsMaterial" uid="uid://symcw0jv0fgr" path="res://Items/Physics/Item_Physics.tres" id="5"]
 
 [sub_resource type="Resource" id="Resource_slot"]
+resource_local_to_scene = true
 script = ExtResource("4")
 itemData = ExtResource("3")
 

--- a/mods/RTVWallets/Leather_Wallet.tscn
+++ b/mods/RTVWallets/Leather_Wallet.tscn
@@ -7,6 +7,7 @@
 [ext_resource type="PhysicsMaterial" path="res://Items/Physics/Item_Physics.tres" id="5"]
 
 [sub_resource type="Resource" id="Resource_slot"]
+resource_local_to_scene = true
 script = ExtResource("4")
 itemData = ExtResource("3")
 

--- a/mods/RTVWallets/MODWORKSHOP_DESCRIPTION.md
+++ b/mods/RTVWallets/MODWORKSHOP_DESCRIPTION.md
@@ -38,6 +38,7 @@ This mod is a **different aesthetic**, not a replacement: cash and wallets are *
 
 - ✅ **Coexists with other registry-using mods** (e.g. CatAutoFeed, etc.). No Database.gd takeover.
 - ❌ **Wallet & Cash** by domfrags — see incompatibility callout above.
+- ❌ **Oldman's Immersive Overhaul** (v3.0.3 and earlier). Different Metro integration patterns don't currently compose; our wallets and cash silently fail to load. Pending a Metro v3 update on Oldman's side. Run one or the other, not both.
 - ⚠ **Uninstalling strips wallets from saves.** Save files reference wallet items via `res://mods/RTVWallets/<Tier>.tres`. Removing the `.vmz` causes the game to silently drop wallets (and any cash they hold) on next load. To migrate cleanly, withdraw cash from all wallets and drop the empty wallets before uninstalling.
 
 ## Credits

--- a/mods/RTVWallets/Money_Case.tscn
+++ b/mods/RTVWallets/Money_Case.tscn
@@ -7,6 +7,7 @@
 [ext_resource type="PhysicsMaterial" path="res://Items/Physics/Item_Physics.tres" id="5"]
 
 [sub_resource type="Resource" id="Resource_slot"]
+resource_local_to_scene = true
 script = ExtResource("4")
 itemData = ExtResource("3")
 

--- a/mods/RTVWallets/PUBLISH_NOTES.md
+++ b/mods/RTVWallets/PUBLISH_NOTES.md
@@ -4,7 +4,9 @@ Internal workspace doc. Not bundled in the .vmz.
 
 ## Status
 
-**Current state: v1.0.1 (live on ModWorkshop as id 56408).** Trader Sell-for-€ flow matches vanilla barter (drain → spill → overflow drops via our `Drop()` override). Cash drag-overlay shows €, drops are clean maxAmount chunks, materials dimmed so cash doesn't glow in dim lighting. MCM trimmed to working settings only. README and CHANGELOG match shipping behavior.
+**Current state: v1.1.0 (publishing).** Hotfix release for #50 (cash duplication exploit, reported by ppfota). Two-part fix: `resource_local_to_scene = true` on every wallet `.tscn`'s SlotData SubResource so fresh placements get unique state, plus a one-shot heal in `WalletPickup._ready` that duplicates shared SlotData on legacy 1.0.2 saves. Same bug shape Cat Bowl 1.1.0 fixed. Existing saves carry forward.
+
+**v1.0.2 (live on ModWorkshop as id 56408)** patched the Metro v3.0.0 `[registry]` empty-section drop. v1.1.0 supersedes.
 
 **Migrated to Metro v3.x registry (2026-04-26).** Database injection goes through `Engine.get_meta("RTVModLib").register(SCENES, ...)` instead of the retired RTVModItemRegistry shim.
 

--- a/mods/RTVWallets/README.md
+++ b/mods/RTVWallets/README.md
@@ -39,6 +39,7 @@ Plus the standard Logger category (level, file output, overlay output). See [the
 ## Compatibility
 
 - **Metro Mod Loader v3.0.0+ required.** Wallet items are added via Metro's registry (`lib.register(SCENES, ...)`), so they coexist cleanly with any other mod also using the registry — no `take_over_path` collisions on Database.gd.
+- **Known incompatibility with [Oldman's Immersive Overhaul](https://modworkshop.net/mod/50811) (v3.0.3 and earlier).** The two mods integrate with Metro through different patterns and don't currently compose: this mod uses Metro v3's `[registry]` API, Oldman's uses a Database-replacement pattern that predates `[registry]`. With both installed, this mod's wallets and cash fail to load at traders, in inventories, or on placement (Metro logs a warning, but the items just don't appear). Not a bug in either mod individually; pending a Metro v3 update on Oldman's side. Workaround until then: run one or the other, not both.
 - **MCM is optional.** The mod runs with sensible defaults if MCM is absent — only used to rebind the Stash Report hotkey.
 - **Conflicts with other "cash economy" mods** (e.g. *Wallet & Cash*). Pick one or the other; both replace the same Trader Buy/Sell flow.
 - **Uninstalling drops wallets and cash.** Save files reference wallet items via `res://mods/RTVWallets/<Tier>.tres`. If you remove the .vmz, the game silently strips wallets (and any cash they hold) from saves on next load. To migrate, withdraw cash from all wallets and drop the empty wallets before uninstalling.

--- a/mods/RTVWallets/WalletPickup.gd
+++ b/mods/RTVWallets/WalletPickup.gd
@@ -9,6 +9,16 @@ extends Pickup
 # call so it doesn't see the raw Sketchfab mesh bounds (tens of metres).
 
 func _ready() -> void:
+    # Heal save-data wallets written before the local_to_scene fix landed:
+    # those wallets' SlotData was serialized while shared, so two ammo tins
+    # in the same save can still point to the same SlotData object on load
+    # even after the .tscn-side fix is in place. Duplicate it here so each
+    # wallet ends up with its own state going forward. One-shot per wallet
+    # per save — subsequent loads see resource_local_to_scene = true and skip.
+    if slotData != null and not slotData.resource_local_to_scene:
+        slotData = slotData.duplicate(true)
+        slotData.resource_local_to_scene = true
+
     var meshes := find_children("*", "MeshInstance3D", true, false)
     if collision and meshes.size() > 0:
         _setup_box_collision_from_combined_aabb(meshes)

--- a/mods/RTVWallets/mod.txt
+++ b/mods/RTVWallets/mod.txt
@@ -1,7 +1,7 @@
 [mod]
 name="RTV Wallets"
 id="RTVWallets"
-version="1.0.2"
+version="1.1.0"
 
 [autoload]
 RTVWalletsLog="res://mods/RTVWallets/Logger.gd"


### PR DESCRIPTION
## Summary

Fixes #50.

- Cash duplication exploit reported by @ppfota: filling one wallet visually filled every other wallet of the same tier in the world. Reload + unload returned the cash on each duplicate, doubling money per pickup-place cycle.
- Root cause: every wallet `.tscn` declared its `SlotData` SubResource without `resource_local_to_scene = true`, so all instances of a tier shared one SlotData object reference. Same shape of bug as the Cat Bowl fix in CatAutoFeed 1.1.0.
- Two-part fix: (1) `resource_local_to_scene = true` on every wallet `.tscn`'s SlotData SubResource so fresh placements get unique state; (2) one-shot heal in `WalletPickup._ready` that duplicates shared SlotData on legacy 1.0.2 saves on first load.
- No save format changes. Existing 1.0.2 saves carry forward and self-repair.

## Release audit

- `mod.txt` 1.0.2 → **1.1.0**
- CHANGELOG entry dated 2026-05-09
- README + MODWORKSHOP_DESCRIPTION add a Compatibility bullet for the known [Oldman's Immersive Overhaul](https://modworkshop.net/mod/50811) (v3.0.3 and earlier) issue (their pre-`[registry]` Database-replacement collides with our Metro v3 registry usage; pending Metro v3 update on their side)
- Workspace `README.md` Mod Releases table updated
- `PUBLISH_NOTES.md` status section refreshed

## Test plan

- [x] Repro `ppfota`'s exact steps on 1.0.2 first to confirm the dup
- [x] Apply 1.1.0 build locally; repro again — dup gone
- [x] Existing 1.0.2 save loads cleanly, runtime heal duplicates SlotData per wallet
- [x] Godot 4.6.2 `--check-only` clean on `WalletPickup.gd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)