### PR TITLE
Release: RTVHideoutLights 1.2.0 (#47 fixture state persistence)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This monorepo houses multiple mods, each with its own independent version. GitHu
 | **Cat Auto Feed** | `1.1.8` | [CatAutoFeed-v1.1.8](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/CatAutoFeed-v1.1.8) | [56407](https://modworkshop.net/mod/56407) |
 | **RTV Mod Logger** | `1.0.2` | [RTVModLogger-v1.0.2](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/RTVModLogger-v1.0.2) | [56406](https://modworkshop.net/mod/56406) |
 | **RTV Wallets** | `1.1.0` | [RTVWallets-v1.1.0](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/RTVWallets-v1.1.0) | [56408](https://modworkshop.net/mod/56408) |
-| **RTV Hideout Lights** | `1.1.0` | [RTVHideoutLights-v1.1.0](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/RTVHideoutLights-v1.1.0) | [56519](https://modworkshop.net/mod/56519) |
+| **RTV Hideout Lights** | `1.2.0` | [RTVHideoutLights-v1.2.0](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/RTVHideoutLights-v1.2.0) | [56519](https://modworkshop.net/mod/56519) |
 | **Punisher Guarantee** | `0.1.0` | [PunisherGuarantee-v0.1.0](https://github.com/dwoodruff83/RoadToVostokMods/releases/tag/PunisherGuarantee-v0.1.0) | — (not yet published) |
 
 ## Game Info

--- a/mods/CatAutoFeed/README.md
+++ b/mods/CatAutoFeed/README.md
@@ -43,6 +43,7 @@ Plus the standard Logger category (level, file output, overlay output). See [the
 ## Compatibility
 
 - **Metro Mod Loader v3.0.0+ required.** Cat_Bowl is added via Metro's registry (`lib.register(SCENES, ...)` and `lib.register(LOOT, ...)`), which means it coexists cleanly with any other mod also using the registry — no `take_over_path` collisions.
+- **Known incompatibility with [Oldman's Immersive Overhaul](https://modworkshop.net/mod/50811) (v3.0.3 and earlier).** The two mods integrate with Metro through different patterns and don't currently compose: this mod uses Metro v3's `[registry]` API, Oldman's uses a Database-replacement pattern that predates `[registry]`. With both installed, the Cat Food Bowl fails to load at the Gunsmith trader, in inventories, in loot containers, or on placement (Metro logs a warning, but the bowl just doesn't appear). Not a bug in either mod individually; pending a Metro v3 update on Oldman's side. Workaround until then: run one or the other, not both.
 - **Incompatible with** other cat-feeding mods (e.g. *Cat Food Shelter*). Remove them before installing to avoid double-feeding.
 - **Likely incompatible with [Put Food Out](https://modworkshop.net/mod/56098)** — both mods touch the cat-feeding loop. Pick one. Untested in combination; if you run both you may get double-feeds or fight over the same hunger ticks.
 - **MCM is optional** — the mod runs with sensible defaults if MCM is absent. It is only required for in-game configuration.

--- a/mods/RTVHideoutLights/CHANGELOG.md
+++ b/mods/RTVHideoutLights/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to the RTV Hideout Lights mod are documented here. Dates are
 YYYY-MM-DD.
 
+## 1.2.0 — 2026-05-09
+
+- **All toggleable fixtures now persist their on/off state across shelter reloads (#47).** Floor Lamp, Vintage Desktop PC, fluorescents, Computer_Lit, **Candle, and Kerosene Lantern** were previously always off after leaving and returning to a shelter, even if you'd lit them. Now their lit state survives between shelter visits, scoped per-fixture-instance so multiple lamps in the same shelter each remember their own state independently. Exit Sign is excluded — it's always-on decorative (matches real emergency-exit lighting) and never had a toggle to begin with.
+  - Mechanism: a sidecar config file at `user://rtvlights_state.cfg` keyed by `shelter_<name>` section, `<file_id>_<x>_<y>_<z>` entry. Position rounded to 1cm.
+  - **Phase 1** covered LightToggle-based fixtures (Lamp / PC / fluorescents / Computer / Sign).
+  - **Phase 2** added Fire-based fixtures (Candle, Kerosene Lantern) via a small `FireStatePersist` observer node attached as a child of each Fire-rooted scene root. The observer polls the parent's `active` flag once per frame and mirrors transitions into the same sidecar. No `take_over_path` on vanilla `Fire.gd`, so vanilla world candles / lanterns / fire pits / barrels are unaffected and keep their existing ~2% spawn-lit behavior.
+  - Switch-controlled fixtures (Cellar Wall Light, Industrial / Bright / Soft Fluorescent) already persisted via vanilla switch state in 1.1.0; they continue to do so. The new sidecar tracks them too as redundant insurance, no behavior change for the player.
+  - **Placement always defaults to off**, matching 1.1.0 behavior. Picking up a fixture and replacing it (anywhere) resets to off; you re-toggle from there. Persistence kicks in for fixtures that stay put between shelter visits — the common case.
+- No save format changes (the sidecar is additive, not part of any vanilla save); existing 1.1.0 saves carry forward. The sidecar is created on first toggle.
+
 ## 1.1.0 — 2026-05-04
 
 Placement and switch-routing overhaul. No save format changes; existing saves carry forward.

--- a/mods/RTVHideoutLights/FireStatePersist.gd
+++ b/mods/RTVHideoutLights/FireStatePersist.gd
@@ -1,0 +1,131 @@
+extends Node
+
+# Phase 2 of #47: persist on/off state for Fire-rooted catalog fixtures
+# (Candle, Kerosene Lantern). Vanilla `Fire.gd` doesn't expose a hook we
+# can latch into the way LightToggle does, so this script attaches as a
+# child of the Fire-rooted scene root and observes the parent's `active`
+# field by polling. On transitions it mirrors the value into
+# LightStateStore (the same sidecar #47 phase 1 introduced for
+# LightToggle fixtures).
+#
+# Why a child observer rather than `take_over_path` on Fire.gd:
+#   - Scoped: only fixtures in OUR scenes get the observer. Vanilla world
+#     candles / lanterns / fire pits / barrels keep their existing 2%
+#     spawn-lit behaviour and are unaffected.
+#   - Mod-coexistence safe: another mod overriding Fire.gd via
+#     take_over_path won't collide with us.
+#   - One ConfigFile write per ignite/extinguish; polling is just a bool
+#     compare per frame, trivially cheap.
+
+const LightStateStoreScript = preload("res://mods/RTVHideoutLights/LightStateStore.gd")
+
+# Cached parent + Furniture sibling. Resolved in _ready and held for the
+# lifetime of the node.
+var _fire_root: Node3D = null
+var _furniture: Node = null
+
+# Last observed active state. _process flips when `_fire_root.active`
+# transitions and writes the new value to LightStateStore.
+var _last_active: bool = false
+
+# Mirrors LightToggle's _initialized: prevents the initial restore pass
+# from triggering a same-value persist write back, and gates `_process`
+# until `_restore_state_from_sidecar` has run.
+var _initialized: bool = false
+
+func _ready() -> void:
+    if Engine.is_editor_hint():
+        return
+    _fire_root = get_parent() as Node3D
+    if _fire_root == null:
+        return
+    _furniture = _fire_root.get_node_or_null("Furniture")
+    # Two timing concerns to clear before we can restore:
+    #
+    # 1. LoadShelter assigns global_position AFTER the add_child that
+    #    triggers _ready, so reading global_position immediately would
+    #    look up the sidecar at (0,0,0) and miss.
+    #
+    # 2. Vanilla Fire.gd._ready does its own `await get_tree().create_timer(0.1)`
+    #    before forcing `active = false` + Deactivate() on the 98% non-lit
+    #    branch of its 2% spawn-lit roll. If we restore inside that 100ms
+    #    window, vanilla clobbers us when it resumes.
+    #
+    # A 0.25s wait covers both: LoadShelter has long since assigned the
+    # saved position (it's a synchronous loop), and Fire's 0.1s timer plus
+    # the random-roll branch has fully completed. Then we override.
+    await get_tree().create_timer(0.25, false).timeout
+    _restore_state_from_sidecar()
+
+func _restore_state_from_sidecar() -> void:
+    if _fire_root == null or not is_instance_valid(_fire_root) or not ("active" in _fire_root):
+        _initialized = true
+        return
+    # Skip during placement preview: the player is dragging the fixture
+    # around, position is mid-flux, and LightFurniture.ResetMove will
+    # deterministically force it off after commit anyway. Restoring now
+    # would just flicker.
+    if _furniture and "isMoving" in _furniture and _furniture.isMoving:
+        _initialized = true
+        _last_active = bool(_fire_root.active)
+        return
+    var shelter := _resolve_shelter_name()
+    var file_id := _resolve_file_id()
+    if shelter.is_empty() or file_id.is_empty():
+        _initialized = true
+        _last_active = bool(_fire_root.active)
+        return
+    if LightStateStoreScript.has_state(shelter, file_id, _fire_root.global_position):
+        var saved: bool = LightStateStoreScript.load_state(shelter, file_id, _fire_root.global_position)
+        if saved and not bool(_fire_root.active):
+            # Re-ignite. Vanilla Fire.Interact sets `active = true` AFTER
+            # calling Activate; we replicate that ordering so the data
+            # stays consistent with vanilla expectations.
+            _fire_root.Activate()
+            _fire_root.active = true
+        elif not saved and bool(_fire_root.active):
+            _fire_root.Deactivate()
+            _fire_root.active = false
+    _last_active = bool(_fire_root.active)
+    _initialized = true
+
+func _process(_delta: float) -> void:
+    if not _initialized:
+        return
+    if _fire_root == null or not is_instance_valid(_fire_root):
+        return
+    if not ("active" in _fire_root):
+        return
+    var current: bool = bool(_fire_root.active)
+    if current == _last_active:
+        return
+    _last_active = current
+    _persist_state(current)
+
+func _persist_state(state: bool) -> void:
+    var shelter := _resolve_shelter_name()
+    var file_id := _resolve_file_id()
+    if shelter.is_empty() or file_id.is_empty():
+        return
+    LightStateStoreScript.save_state(shelter, file_id, _fire_root.global_position, state)
+
+func _resolve_shelter_name() -> String:
+    var scene = get_tree().current_scene
+    if scene == null:
+        return ""
+    var map_node = scene.get_node_or_null("/root/Map")
+    if map_node == null:
+        return ""
+    var m = map_node.get("mapName")
+    return String(m) if m != null else ""
+
+# The Furniture sibling carries the catalog ItemData resource — `file` is
+# the stable per-SKU id (`rtvlights_candle`, `rtvlights_lantern_kerosene`)
+# that the same fixture uses across save/load.
+func _resolve_file_id() -> String:
+    if _furniture == null or not ("itemData" in _furniture):
+        return ""
+    var item_data = _furniture.itemData
+    if item_data == null or not ("file" in item_data):
+        return ""
+    return String(item_data.file)

--- a/mods/RTVHideoutLights/LightFurniture.gd
+++ b/mods/RTVHideoutLights/LightFurniture.gd
@@ -78,10 +78,20 @@ func ResetMove() -> void:
         _set_preview_visible(true)
         return
 
-    # Force the fixture off after placement (user-spec'd: "off when
-    # placed"). super.ResetMove just restored sourceMaterials including
-    # the LIT swap variant where applicable, so we re-apply Deactivate to
-    # put the swap surface back to the off material AND hide lights.
+    # Force the fixture off after placement (1.1.0 behavior). super.ResetMove
+    # just restored sourceMaterials including the LIT swap variant where
+    # applicable, so we re-apply Deactivate to put the swap surface back to
+    # the off material AND hide lights.
+    #
+    # An earlier 1.2.0 build tried to "restore from sidecar" here so that
+    # picking up and re-placing a lit fixture preserved its state. That
+    # caused two bugs: (1) on PC, the swap-mesh material and Light3D
+    # visibility could desync because the deferred sidecar read in
+    # LightToggle._ready raced the placement preview hide; (2) a sidecar
+    # entry left behind by a previous fixture at the same position would
+    # latch onto a freshly-placed different fixture. Simpler design wins:
+    # every commit defaults to off, the sidecar entry gets overwritten with
+    # false, and stale entries can't leak across fixtures.
     if root.has_method("Deactivate"):
         root.Deactivate()
 

--- a/mods/RTVHideoutLights/LightStateStore.gd
+++ b/mods/RTVHideoutLights/LightStateStore.gd
@@ -1,0 +1,65 @@
+class_name LightStateStore
+extends RefCounted
+
+# Sidecar persistence for placed-fixture lit state.
+#
+# Vanilla shelter saves serialize FurnitureSave (position, rotation, scale,
+# itemData, storage), but NOT arbitrary script-level state like
+# `LightToggle.active`. So a Floor Lamp the player turned on always loads
+# back as off. This file plugs that hole by mirroring each manual fixture's
+# active flag into a separate ConfigFile keyed by shelter + fixture file
+# id + world position.
+#
+# All methods are static — no autoload needed. The ConfigFile is lazily
+# loaded on first access and cached in a static var, so per-shelter visits
+# pay one disk read followed by in-memory writes (each `set_value` triggers
+# a save() so a crash mid-toggle still preserves the most recent state).
+#
+# Issue #47.
+
+const PATH := "user://rtvlights_state.cfg"
+
+# Single-instance ConfigFile cache. Lazily initialised on first call;
+# survives full mod reload because static state is bound to the script
+# resource, not a node instance.
+static var _cache: ConfigFile = null
+
+static func _config() -> ConfigFile:
+	if _cache != null:
+		return _cache
+	_cache = ConfigFile.new()
+	# `load` returns ERR_FILE_NOT_FOUND on first run; that's expected and
+	# leaves the ConfigFile empty. We don't surface the error.
+	_cache.load(PATH)
+	return _cache
+
+# Persist the lit state of a single fixture. Section is per-shelter so a
+# bunker's Floor Lamp doesn't collide with a cabin's at the same x/y/z.
+# Position is rounded to 2dp (1cm) to immunize the key against float drift
+# when the player picks up and re-places at "the same spot".
+static func save_state(shelter: String, file_id: String, position: Vector3, active: bool) -> void:
+	if shelter.is_empty() or file_id.is_empty():
+		return
+	var cfg := _config()
+	cfg.set_value(_section(shelter), _make_key(file_id, position), active)
+	cfg.save(PATH)
+
+# Returns saved state, or `default` if no entry exists for this fixture.
+static func load_state(shelter: String, file_id: String, position: Vector3, default: bool = false) -> bool:
+	if shelter.is_empty() or file_id.is_empty():
+		return default
+	var cfg := _config()
+	return bool(cfg.get_value(_section(shelter), _make_key(file_id, position), default))
+
+# True iff a sidecar entry exists for this fixture (regardless of value).
+# Lets callers tell "no entry, use default" apart from "entry says false".
+static func has_state(shelter: String, file_id: String, position: Vector3) -> bool:
+	if shelter.is_empty() or file_id.is_empty():
+		return false
+	return _config().has_section_key(_section(shelter), _make_key(file_id, position))
+
+static func _section(shelter: String) -> String:
+	return "shelter_" + shelter
+
+static func _make_key(file_id: String, pos: Vector3) -> String:
+	return "%s_%.2f_%.2f_%.2f" % [file_id.to_lower(), pos.x, pos.y, pos.z]

--- a/mods/RTVHideoutLights/LightToggle.gd
+++ b/mods/RTVHideoutLights/LightToggle.gd
@@ -65,19 +65,65 @@ var gameData = preload("res://Resources/GameData.tres")
 # crash the game on dead.Deactivate().
 var _subscribed_switch: Node = null
 
+# Guards Activate/Deactivate against writing to LightStateStore during the
+# initial _ready setup pass. Without this, the default Deactivate() call
+# below would clobber any saved-true state for this fixture, defeating the
+# whole point of #47. Flipped to true at the end of _ready, after the
+# initial state has been set.
+var _initialized: bool = false
+
+const LightStateStoreScript = preload("res://mods/RTVHideoutLights/LightStateStore.gd")
+
 func _ready() -> void:
     if Engine.is_editor_hint():
         return
-    # Set initial state. Default is off; force_on flips that.
+    # Provisional initial state. Vanilla Loader.LoadShelter does
+    # `map.add_child(furniture); furniture.global_position = ...`, so _ready
+    # fires BEFORE the saved position is applied — reading global_position
+    # here gives (0,0,0) and the sidecar lookup misses. We therefore set a
+    # safe default now and defer the real restore to next idle frame, by
+    # which time LoadShelter has finished writing position.
     if force_on:
         Activate()
     else:
         Deactivate()
+    call_deferred("_restore_state_from_sidecar")
     # Subscribe to shelter Switch if enabled. Brief delay so the shelter
     # scene's switch is fully initialized before we touch its array.
     if subscribe_to_switch:
         await get_tree().create_timer(0.5, false).timeout
         _try_subscribe_to_switch()
+
+# Reads the sidecar at the now-correct global_position and overrides the
+# provisional state set by _ready. Used for the leave-and-return shelter
+# load path; placement commits go through LightFurniture.ResetMove and
+# always default to off (any sidecar entry there is then overwritten by
+# Deactivate's _persist_state).
+func _restore_state_from_sidecar() -> void:
+    # Skip during placement preview. ResetMove() will deterministically
+    # set the post-commit state via Deactivate, so a deferred restore here
+    # would just flicker the lights mid-drag and pollute the sidecar with
+    # entries at random preview-cursor positions.
+    var furniture := get_node_or_null("Furniture")
+    if furniture and "isMoving" in furniture and furniture.isMoving:
+        _initialized = true
+        return
+    var shelter := _resolve_shelter_name()
+    var file_id := _resolve_file_id()
+    if shelter.is_empty() or file_id.is_empty():
+        _initialized = true
+        return
+    if LightStateStoreScript.has_state(shelter, file_id, global_position):
+        var saved: bool = LightStateStoreScript.load_state(shelter, file_id, global_position)
+        # Suppress persist-back during the restore itself: we'd otherwise
+        # rewrite the same value we just read, which is wasteful and adds
+        # noise to logs if we ever instrument this.
+        _initialized = false
+        if saved:
+            Activate()
+        else:
+            Deactivate()
+    _initialized = true
 
 func Interact() -> void:
     # Only fire on Use action when interactable; otherwise the Switch is
@@ -99,6 +145,7 @@ func Activate() -> void:
             n.visible = true
     if is_instance_valid(swap_mesh) and swap_on_material:
         swap_mesh.set_surface_override_material(swap_surface_index, swap_on_material)
+    _persist_state()
 
 func Deactivate() -> void:
     active = false
@@ -110,6 +157,49 @@ func Deactivate() -> void:
             n.visible = false
     if is_instance_valid(swap_mesh) and swap_off_material:
         swap_mesh.set_surface_override_material(swap_surface_index, swap_off_material)
+    _persist_state()
+
+# Mirror our `active` flag into the LightStateStore sidecar so the next
+# shelter load can restore it. Skipped during the _ready setup pass to
+# avoid clobbering saved-true state with a default Deactivate(). Switch-
+# controlled fixtures (subscribe_to_switch=true) also call through here
+# during their subscription sync; that's redundant with the vanilla
+# Switch save but harmless and keeps the code path uniform.
+func _persist_state() -> void:
+    if not _initialized:
+        return
+    var shelter := _resolve_shelter_name()
+    var file_id := _resolve_file_id()
+    if shelter.is_empty() or file_id.is_empty():
+        return
+    LightStateStoreScript.save_state(shelter, file_id, global_position, active)
+
+# Resolves the current shelter name from /root/Map.mapName, mirroring the
+# pattern CatAutoFeed and RTVWallets use. Returns "" when not in a shelter
+# (e.g., overworld map) so persistence is a no-op there.
+func _resolve_shelter_name() -> String:
+    var scene = get_tree().current_scene
+    if scene == null:
+        return ""
+    var map_node = scene.get_node_or_null("/root/Map")
+    if map_node == null:
+        return ""
+    var m = map_node.get("mapName")
+    return String(m) if m != null else ""
+
+# Looks up our sibling Furniture node and reads its itemData.file. The
+# Furniture node is added at .tscn build time as a child of the scene root
+# (see scenes/rtvlights_*_F.tscn) and carries the catalog ItemData
+# resource — that resource's `file` field is the stable per-SKU id we
+# want as part of the sidecar key.
+func _resolve_file_id() -> String:
+    var furniture := get_node_or_null("Furniture")
+    if furniture == null or not ("itemData" in furniture):
+        return ""
+    var item_data = furniture.itemData
+    if item_data == null or not ("file" in item_data):
+        return ""
+    return String(item_data.file)
 
 func UpdateTooltip() -> void:
     if not interactable:

--- a/mods/RTVHideoutLights/MODWORKSHOP_DESCRIPTION.md
+++ b/mods/RTVHideoutLights/MODWORKSHOP_DESCRIPTION.md
@@ -1,0 +1,68 @@
+# RTV Hideout Lights
+
+> Nine placeable light fixtures stocked by every trader (Generalist, Gunsmith, Doctor). Vanilla-quality lamps, lanterns, candles, fluorescents, and an exit sign. Toggle some on/off via Use; ceiling fixtures wire into your shelter's existing wall switch. State persists across shelter visits as of v1.2.0.
+
+Vanilla Road to Vostok has dozens of light fixtures baked into the world (industrial fluorescents, cellar sconces, exit signs) but none are placeable furniture. This mod takes those existing assets and turns them into furniture you buy from any of the three traders and place via the standard decor mode.
+
+Ships **zero new mesh or texture data**. Every model and material loads from the game install you already have. The .vmz weighs ~1.2 MB, mostly trader catalog icons.
+
+---
+
+## ⚠ Compatibility
+
+- ❌ **[Oldman's Immersive Overhaul](https://modworkshop.net/mod/50811)** (v3.0.3 and earlier) — different Metro integration patterns don't currently compose; our fixtures silently fail to load. Pending a Metro v3 update on Oldman's side. Run one or the other, not both.
+- ✅ **Coexists with other registry-using mods** (Cat Auto Feed, RTV Wallets, etc.). No `Database.gd` takeover — uses Metro's `[registry]` API.
+- ✅ **Coexists with vanilla shelter lighting.** Wiring a mod fixture into the shelter switch only appends to the switch's `targets` array; vanilla lights keep working alongside.
+
+---
+
+## What's in the catalog
+
+Every fixture is stocked by all three currently-revealed traders (Generalist, Gunsmith, Doctor) so v1 users see them no matter where they shop.
+
+| Fixture | Mount | Toggle | Notes |
+|---|---|---|---|
+| **Candle** | Floor (2x2) | Use to light/extinguish | Tiny warm flame, ~1m falloff. Cheap. |
+| **Kerosene Lantern** | Floor (2x3) | Use to light/extinguish | Brighter than the candle, ~4m range. |
+| **Floor Lamp** | Floor (3x6) | Use to toggle | Warm 50° spotlight inside the shade. Tall (needs ~2m clearance). |
+| **Vintage Desktop PC** | Floor (4x4) | Use to toggle | Cyan glow + animated lit-screen UI when on; dark monitor when off. |
+| **Exit Sign** | Wall (3x2) | Always on | Green-glow sconce. Reads "EXIT" at a glance. |
+| **Cellar Wall Light** | Wall (2x3) | Shelter switch | Warm bare bulb behind a metal cage. |
+| **Industrial Fluorescent** | Ceiling (2x2) | Shelter switch | Square ceiling panel, neutral white. |
+| **Bright Fluorescent** | Ceiling (5x2) | Shelter switch | Long fluorescent tube, high energy. Cabin/garage feel. |
+| **Soft Fluorescent** | Ceiling (5x2) | Shelter switch | Same shape as Bright, lower energy, no fog beam. Bedroom feel. |
+
+## Switch integration
+
+Shelters with a vanilla **Light_Switch** (Cabin, Bunker, Classroom) already control their built-in lights. Place any fixture marked "Shelter switch" above and the mod auto-subscribes it to the room's switch. Multi-switch shelters (the Cabin has one switch per room) get smart room-aware routing: the mod picks the switch whose existing static lights are nearest, so a fixture in the bedroom joins the bedroom's switch, not the kitchen's.
+
+Shelters without a switch (Tent, Attic) leave wired fixtures permanently on. The Floor Lamp, PC, Candle, Lantern, and Exit Sign work in any shelter — they have their own toggle (Use action) or are always-on.
+
+## Placement and state
+
+Picking a fixture up to move it always turns it off for the placement preview, so the green hologram renders cleanly and the fixture lands in a known state. On commit, switch-controlled fixtures sync to the nearest room switch, manual fixtures start off (player turns them on with Use), and always-on fixtures (Exit Sign) light back up.
+
+**State persistence (1.2.0+).** Every toggleable fixture remembers its on/off state between shelter visits. Light a Floor Lamp or Candle, leave the shelter, come back, it's still lit. Multiple fixtures in the same shelter each keep their own state independently. Re-placing a fixture defaults it to off (matches 1.1.0 placement behavior). State lives in a small sidecar config alongside your save (`user://rtvlights_state.cfg`); no vanilla save format changes.
+
+## Configuration (MCM)
+
+The mod has no settings of its own. The standard Logger category (level, file output, overlay output) is exposed via MCM if you want to tune it.
+
+## Requirements
+
+- **[Metro Mod Loader](https://modworkshop.net/mod/55623) v3.0.0 or later** — required. Uses Metro's `[registry]` API.
+- **[Mod Configuration Menu (MCM)](https://modworkshop.net/mod/53713)** — optional. The mod runs with sensible defaults if MCM is absent; only required if you want to tune the logger.
+
+## Uninstalling
+
+Save files reference each fixture via `res://mods/RTVHideoutLights/...`. Removing the `.vmz` silently strips placed lights from saves on next load. **Pick everything up before uninstalling.**
+
+## Credits
+
+All meshes, textures, and materials are vanilla Road to Vostok assets, loaded from the game install at runtime. The mod ships zero asset data.
+
+In-game configuration via [Mod Configuration Menu](https://modworkshop.net/mod/53713) by DoinkOink. Mod-loader infrastructure by Metro.
+
+## License
+
+[MIT](https://opensource.org/license/mit) for the mod code. Vanilla game assets remain the property of the Road to Vostok developers; this mod ships zero asset data.

--- a/mods/RTVHideoutLights/PUBLISH_NOTES.md
+++ b/mods/RTVHideoutLights/PUBLISH_NOTES.md
@@ -4,7 +4,7 @@ Internal workspace doc. Not bundled in the .vmz.
 
 ## Status
 
-**Current state:** v1.1.0 (about to publish). Live on ModWorkshop as id 56519. v1.0.1 (live) hardened the `[registry]` section to survive Metro v3.0.0 ConfigFile parsing. v1.1.0 ships placement-preview cleanup, "off-on-pickup, sync-to-switch-on-drop" lifecycle, and room-aware switch routing (subscribes to whichever switch's static lights are nearest, so multi-room shelters like the Cabin work correctly).
+**Current state:** v1.2.0 (about to publish). Live on ModWorkshop as id 56519. v1.1.0 (live) shipped placement-preview cleanup and room-aware switch routing. v1.2.0 closes #47: every toggleable fixture (Floor Lamp, PC, fluorescents, Computer_Lit, Candle, Kerosene Lantern) now persists its on/off state across shelter visits via a sidecar config file (`user://rtvlights_state.cfg`), per-shelter and per-position. Phase 1 covered LightToggle-based fixtures; Phase 2 added Fire-based ones via a small observer node (no `take_over_path` on vanilla `Fire.gd`, so vanilla world fires are unaffected). Exit Sign intentionally excluded — always-on by design.
 
 Nine placeable light fixtures, stocked by all three currently-revealed traders (Generalist, Gunsmith, Doctor). Grandma intentionally skipped (still story-hidden). Metro v3.0+ hard-required (uses `[registry]` API). MCM optional (only the Logger category attaches; mod has no settings of its own). All assets are vanilla `res://Assets/...` references; the mod ships zero mesh/texture data, only trader-catalog icons and a handful of `.tscn` / `.tres` wrappers + `.gd` scripts.
 

--- a/mods/RTVHideoutLights/README.md
+++ b/mods/RTVHideoutLights/README.md
@@ -49,6 +49,8 @@ Picking a fixture up to move it always turns it off for the duration of the plac
 
 When a fixture is off, both the Light3D source and the emissive lampshade material go dark (same pattern as the vanilla cabin pendants).
 
+**State persistence (1.2.0+):** Every toggleable fixture remembers its on/off state between shelter visits. Light a Floor Lamp or Candle, leave the shelter, come back, it's still lit. Multiple fixtures in the same shelter each keep their own state. State is per-shelter and per-position, stored alongside your save in `user://rtvlights_state.cfg`. Picking up and re-placing any fixture defaults it to off (matches 1.1.0 placement behavior). Exit Sign is intentionally excluded — it's an always-on decorative fixture, like a real emergency exit sign that stays lit even in a power outage.
+
 ## Configuration (MCM)
 
 The mod has no settings of its own. The standard Logger category (level, file output, overlay output) is exposed via MCM. See [the RTV Mod Logger reference](https://github.com/dwoodruff83/RoadToVostokMods/blob/main/mods/RTVModLogger/LOGGER.md).
@@ -56,6 +58,7 @@ The mod has no settings of its own. The standard Logger category (level, file ou
 ## Compatibility
 
 - **Metro Mod Loader v3.0.0+ required.** Fixtures register via Metro's `lib.register(SCENES/ITEMS/LOOT/TRADER_POOLS, ...)`. No `take_over_path` collisions with other registry-using mods.
+- **Known incompatibility with [Oldman's Immersive Overhaul](https://modworkshop.net/mod/50811) (v3.0.3 and earlier).** The two mods integrate with Metro through different patterns and don't currently compose: this mod uses Metro v3's `[registry]` API, Oldman's uses a Database-replacement pattern that predates `[registry]`. With both installed, this mod's fixtures fail to load at traders, in inventories, or on placement (Metro logs a warning, but the items just don't appear). Not a bug in either mod individually; pending a Metro v3 update on Oldman's side. Workaround until then: run one or the other, not both.
 - **MCM is optional.**
 - **Coexists with vanilla shelter lighting.** Wiring a mod fixture into the shelter switch only appends to the switch's `targets` array; vanilla lights keep working alongside.
 - **Uninstalling drops your placed lights.** Saves reference each fixture via `res://mods/RTVHideoutLights/...`. Removing the .vmz silently strips them on next load. Pick everything up before uninstalling.

--- a/mods/RTVHideoutLights/build.py
+++ b/mods/RTVHideoutLights/build.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 MOD_ID = "RTVHideoutLights"
 ROOT_FILES = ['mod.txt', 'README.md', 'CHANGELOG.md', 'NOTICES.txt', 'LICENSE']
-MOD_FILES = ['Main.gd', 'config.gd', 'Logger.gd', 'LightFurniture.gd', 'LightToggle.gd']
+MOD_FILES = ['Main.gd', 'config.gd', 'Logger.gd', 'LightFurniture.gd', 'LightToggle.gd', 'LightStateStore.gd', 'FireStatePersist.gd']
 ASSET_DIRS = ["assets", "scenes", "items"]
 GAME_MODS_DIR = Path(r"C:\Program Files (x86)\Steam\steamapps\common\Road to Vostok\mods")
 VERSION_RE = re.compile(r'^(version\s*=\s*)"([^"]+)"', re.MULTILINE)

--- a/mods/RTVHideoutLights/mod.txt
+++ b/mods/RTVHideoutLights/mod.txt
@@ -1,7 +1,7 @@
 [mod]
 name="RTV Hideout Lights"
 id="RTVHideoutLights"
-version="1.1.0"
+version="1.2.0"
 
 [autoload]
 RTVHideoutLightsLog="res://mods/RTVHideoutLights/Logger.gd"

--- a/mods/RTVHideoutLights/scenes/rtvlights_candle_F.tscn
+++ b/mods/RTVHideoutLights/scenes/rtvlights_candle_F.tscn
@@ -13,6 +13,7 @@
 [ext_resource type="Material" path="res://Effects/Files/MT_Candle_Fire.tres" id="21"]
 [ext_resource type="Material" path="res://Effects/Emitters/Fire.tres" id="22"]
 [ext_resource type="Script" path="res://Scripts/Flicker.gd" id="23"]
+[ext_resource type="Script" path="res://mods/RTVHideoutLights/FireStatePersist.gd" id="24"]
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_collider"]
 size = Vector3(0.3, 0.104, 0.3)
@@ -140,3 +141,6 @@ target_position = Vector3(0, -0.2, 0)
 [node name="Hint" type="MeshInstance3D" parent="Furniture"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.0, 0.052, 0.0)
 mesh = SubResource("PlaneMesh_hint")
+
+[node name="StatePersist" type="Node" parent="."]
+script = ExtResource("24")

--- a/mods/RTVHideoutLights/scenes/rtvlights_lantern_kerosene_F.tscn
+++ b/mods/RTVHideoutLights/scenes/rtvlights_lantern_kerosene_F.tscn
@@ -14,6 +14,7 @@
 [ext_resource type="Material" path="res://Effects/Files/MT_Candle_Fire.tres" id="21"]
 [ext_resource type="Material" path="res://Effects/Emitters/Fire.tres" id="22"]
 [ext_resource type="Script" path="res://Scripts/Flicker.gd" id="23"]
+[ext_resource type="Script" path="res://mods/RTVHideoutLights/FireStatePersist.gd" id="24"]
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_collider"]
 size = Vector3(0.15028, 0.302722, 0.13985599999999998)
@@ -143,3 +144,6 @@ target_position = Vector3(0, -0.2, 0)
 [node name="Hint" type="MeshInstance3D" parent="Furniture"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.0, 0.151361, -4.9999999999980616e-06)
 mesh = SubResource("PlaneMesh_hint")
+
+[node name="StatePersist" type="Node" parent="."]
+script = ExtResource("24")


### PR DESCRIPTION
Promotes the RTVHideoutLights 1.2.0 release from staging to main. Single commit:

- 778d263 — RTVHideoutLights 1.2.0: persist toggleable fixture state across shelter visits (#47) (#54)

Closes #47 on merge.

## Post-merge to-do
- Tag `RTVHideoutLights-v1.2.0` at the new main HEAD
- GitHub release with the built `.vmz` attached
- ModWorkshop upload (manual) + Clear Primary Download
- Comment on #47 with the published version link and close the issue
- Reset local staging to origin/main per the post-squash resync ritual
- Follow-up small PR direct to staging: fix the wallet uninstall doc (cash items disappear too, not just wallets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)